### PR TITLE
fix: in progress status color after fetch task details

### DIFF
--- a/src/frontend/wwwroot/task/task.js
+++ b/src/frontend/wwwroot/task/task.js
@@ -584,6 +584,9 @@
     if (task.overall_status === "completed") {
       removeClassesExcept(taskStatusTag, "tag");
       taskStatusTag.classList.add("is-success");
+    } else if (task.overall_status === "in_progress") {
+      removeClassesExcept(taskStatusTag, "tag");
+      taskStatusTag.classList.add("is-info");
     }
   };
 


### PR DESCRIPTION

While switching pause to start after fetch task details color of status label updated.

![image](https://github.com/user-attachments/assets/92f6cf57-bd11-49d8-92b9-93a3d7aeb9b7)
