### PR TITLE
fix: After pausing the task, if user input is provided, status changes to in-progress but pause icon remains same at the top

### DIFF
--- a/src/frontend/wwwroot/task/task.js
+++ b/src/frontend/wwwroot/task/task.js
@@ -627,6 +627,12 @@
     } else if (task.overall_status === "in_progress") {
       removeClassesExcept(taskStatusTag, "tag");
       taskStatusTag.classList.add("is-info");
+      const iconElement = taskPauseButton.querySelector("i");
+         if (iconElement.classList.contains("fa-circle-play")) {
+           iconElement.classList.remove("fa-circle-play");
+           iconElement.classList.add("fa-circle-pause");
+         }
+
     }
     handleDisableOfActions(task.overall_status)
   };


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* After pausing the task, if user input is provided, status changes to in-progress along with the icon. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->