### PR TITLE
fix: removed the condition from docker login step

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -32,6 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Log in to Azure Container Registry
+        if: ${{ (github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix') }}
         uses: azure/docker-login@v2
         with:
           login-server: ${{ secrets.ACR_LOGIN_SERVER }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -32,7 +32,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Log in to Azure Container Registry
-        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix') }}
         uses: azure/docker-login@v2
         with:
           login-server: ${{ secrets.ACR_LOGIN_SERVER }}


### PR DESCRIPTION
## Purpose
This pull request includes a change to the `.github/workflows/docker-build-and-push.yml` file to simplify the workflow conditions for logging into the Azure Container Registry.

Workflow simplification:

* [`.github/workflows/docker-build-and-push.yml`](diffhunk://#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5L35): Removed the conditional statement for logging into the Azure Container Registry, which previously checked if the event name was 'push' and the branch was 'main', 'dev', 'demo', or 'hotfix'.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

