### PR TITLE
fix: created time inconsistencies

### DIFF
--- a/src/backend/models/messages_kernel.py
+++ b/src/backend/models/messages_kernel.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime,timezone
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
@@ -93,7 +93,7 @@ class BaseDataModel(KernelBaseModel):
     """Base data model with common fields."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    timestamp: Optional[datetime] = Field(default_factory=datetime.utcnow)
+    timestamp: Optional[datetime] = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 # Basic message class for Semantic Kernel compatibility


### PR DESCRIPTION
## Purpose
This pull request updates the `src/backend/models/messages_kernel.py` file to ensure proper handling of timezone-aware timestamps. The changes involve importing the `timezone` module and modifying the `timestamp` field to use `datetime.now(timezone.utc)` instead of `datetime.utcnow`.

### Updates to timezone handling:

* [`src/backend/models/messages_kernel.py`](diffhunk://#diff-933a7e4355b07f9fb84c01b541dac40292d6b9591fbb97be9e67488ec8002197L2-R2): Updated the import statement to include `timezone` from the `datetime` module.
* [`class BaseDataModel`](diffhunk://#diff-933a7e4355b07f9fb84c01b541dac40292d6b9591fbb97be9e67488ec8002197L96-R96): Changed the `timestamp` field's default factory from `datetime.utcnow` to `datetime.now(timezone.utc)` to ensure timestamps are timezone-aware.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No