### PR TITLE
fix: Add Disclaimer Example function stub - not implemented

### DIFF
--- a/src/frontend/wwwroot/task/task.js
+++ b/src/frontend/wwwroot/task/task.js
@@ -528,6 +528,12 @@
                                                 ${markdownConverter.makeHtml(
                   message.content
                 )} ${approveAllStagesButton}
+                ${message.source !== "Planner_Agent" && message.source !== "Group_Chat_Manager" ? `
+                  <div class="is-size-7 has-text-weight-medium has-text-grey-light is-flex" style="font-style: italic;">
+                    Disclaimer: Example function stub - not implemented
+                  </div>
+                ` : ''}
+                    
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Purpose
This pull request introduces a minor update to the `src/frontend/wwwroot/task/task.js` file. It adds a disclaimer message for specific message sources to indicate that a function is a stub and not yet implemented. This is resolution of bug "Bug - Some stages tell user about info that is not presented (stub messages)"

* **User Interface Update**:
  * Added a conditional disclaimer message styled with italic text and light grey color for messages where the source is neither `Planner_Agent` nor `Group_Chat_Manager`. The disclaimer states: "Disclaimer: Example function stub - not implemented."

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
* Go to MACAE App
* Create Task
* Approve steps
* Check at the response of each step will have disclaimer

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->