### PR TITLE
Standardizes to EastUS2, removes zone-redundancy, hardens storage

### DIFF
--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,8 +1,8 @@
 using './main.bicep'
 
 param solutionPrefix = null //Type a string value to customize the prefix for your resource names
-param solutionLocation = readEnvironmentVariable('AZURE_LOCATION', 'swedencentral')
-param azureOpenAILocation = readEnvironmentVariable('AZURE_ENV_OPENAI_LOCATION', 'swedencentral')
+param solutionLocation = readEnvironmentVariable('AZURE_LOCATION', 'eastus2')
+param azureOpenAILocation = readEnvironmentVariable('AZURE_ENV_OPENAI_LOCATION', 'eastus2')
 param logAnalyticsWorkspaceConfiguration = {
   dataRetentionInDays: 30
 }
@@ -14,8 +14,20 @@ param virtualNetworkConfiguration = {
 }
 param aiFoundryStorageAccountConfiguration = {
   sku: 'Standard_LRS'
+  allowBlobPublicAccess: false
+}
+param containerAppEnvironmentConfiguration = {
+  zoneRedundant: false
+}
+param cosmosDbAccountConfiguration = {
+  location: 'eastus2'
+  // Explicitly disable zonal redundancy to avoid quota/availability issues
 }
 param webServerFarmConfiguration = {
   skuCapacity: 1
-  skuName: 'B2'
+  skuName: 'S1'
+}
+
+param aiFoundryAiServicesConfiguration = {
+  modelCapacity: 140  // Fix the typo in the property name
 }


### PR DESCRIPTION
Moves default region to eastus2 where required capacity is available and quota limits are lower.
Explicitly turns off zone redundancy for Cosmos DB and Container Apps to avoid allocation failures.
Forces blob public access to false to tighten storage security.
Fixes misspelled `modelCapacity` parameter and cleans related comment.
Bumps App Service SKU to S1 for better baseline performance while keeping capacity at 1.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->