### PR TITLE
feat: added rate limit error pop up

### DIFF
--- a/src/backend/app_kernel.py
+++ b/src/backend/app_kernel.py
@@ -185,7 +185,7 @@ async def input_task_endpoint(input_task: InputTask, request: Request):
                 "error": str(e),
             },
         )
-        raise HTTPException(status_code=400, detail="Error creating plan")
+        raise HTTPException(status_code=400, detail=f"Error creating plan: {e}")
 
 
 @app.post("/api/human_feedback")

--- a/src/backend/kernel_agents/planner_agent.py
+++ b/src/backend/kernel_agents/planner_agent.py
@@ -434,7 +434,13 @@ class PlannerAgent(BaseAgent):
             return plan, steps
 
         except Exception as e:
-            logging.exception(f"Error creating structured plan: {e}")
+            error_message = str(e)
+            if "Rate limit is exceeded" in error_message:
+                logging.warning("Rate limit hit. Consider retrying after some delay.")
+                raise
+            else:
+                logging.exception(f"Error creating structured plan: {e}")
+        
 
             # Create a fallback dummy plan when parsing fails
             logging.info("Creating fallback dummy plan due to parsing error")

--- a/src/backend/kernel_agents/planner_agent.py
+++ b/src/backend/kernel_agents/planner_agent.py
@@ -440,7 +440,6 @@ class PlannerAgent(BaseAgent):
                 raise
             else:
                 logging.exception(f"Error creating structured plan: {e}")
-        
 
             # Create a fallback dummy plan when parsing fails
             logging.info("Creating fallback dummy plan due to parsing error")

--- a/src/frontend/wwwroot/home/home.js
+++ b/src/frontend/wwwroot/home/home.js
@@ -103,6 +103,16 @@
         })
           .then((response) => response.json())
           .then((data) => {
+            // Check if 'detail' field contains rate limit error
+            if (data.detail && data.detail.includes("Rate limit is exceeded")) {
+              notyf.error("Application temporarily unavailable due to quota limits. Please try again later.");
+              newTaskPrompt.disabled = false;
+              startTaskButton.disabled = false;
+              startTaskButton.classList.remove("is-loading");
+              hideOverlay();
+              return;
+            }
+            
             if (data.status == "Plan not created" || data.plan_id == "") {
               notyf.error("Unable to create plan for this task.");
               newTaskPrompt.disabled = false;


### PR DESCRIPTION
## Purpose
This pull request introduces enhanced error handling for rate limit scenarios and improves error messaging across the backend and frontend. The changes aim to provide more informative feedback to users and developers when encountering specific errors, such as rate limits or plan creation issues.

### Backend Error Handling Improvements:
* [`src/backend/app_kernel.py`](diffhunk://#diff-c839d97b372f2799977f9f197d6c18667f795b2566b1b2c42e27b1479be26173L188-R188): Updated the `input_task_endpoint` to include the exception message in the HTTP error response for better debugging.
* [`src/backend/kernel_agents/planner_agent.py`](diffhunk://#diff-26fed13874b0912fe85301592ef349a3ac2979e6791f384ff7aaacf87ab8b5d1R437-R444): Added logic to detect rate limit errors, log a warning suggesting retrying later, and raise the exception explicitly. Improved logging for structured plan creation failures.

### Frontend Error Messaging Enhancements:
* [`src/frontend/wwwroot/home/home.js`](diffhunk://#diff-020296cc41279c2fc95dc7b8718602444707dc6a994f562e422585ba970860f5R106-R115): Implemented a check for rate limit errors in the API response. Displays a user-friendly notification when rate limits are exceeded and resets the UI elements to ensure usability.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No