### PR TITLE
fix: To reuse Log Analytics across subscriptions

### DIFF
--- a/infra/modules/container-app-environment.bicep
+++ b/infra/modules/container-app-environment.bicep
@@ -10,12 +10,13 @@ param enableTelemetry bool
 param subnetResourceId string
 param applicationInsightsConnectionString string
 
+var existingLawSubscription = split(logAnalyticsResourceId, '/')[2]
 var logAnalyticsResourceGroup = split(logAnalyticsResourceId, '/')[4]
 var logAnalyticsName = split(logAnalyticsResourceId, '/')[8]
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' existing = {
   name: logAnalyticsName
-  scope: resourceGroup(logAnalyticsResourceGroup)
+  scope: resourceGroup(existingLawSubscription, logAnalyticsResourceGroup)
 }
 
 // resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-08-02-preview' = {

--- a/infra/modules/container-app-environment.bicep
+++ b/infra/modules/container-app-environment.bicep
@@ -10,13 +10,13 @@ param enableTelemetry bool
 param subnetResourceId string
 param applicationInsightsConnectionString string
 
-var existingLawSubscription = split(logAnalyticsResourceId, '/')[2]
+var logAnalyticsSubscription = split(logAnalyticsResourceId, '/')[2]
 var logAnalyticsResourceGroup = split(logAnalyticsResourceId, '/')[4]
 var logAnalyticsName = split(logAnalyticsResourceId, '/')[8]
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' existing = {
   name: logAnalyticsName
-  scope: resourceGroup(existingLawSubscription, logAnalyticsResourceGroup)
+  scope: resourceGroup(logAnalyticsSubscription, logAnalyticsResourceGroup)
 }
 
 // resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-08-02-preview' = {


### PR DESCRIPTION
## Purpose
This pull request introduces a change to the `infra/modules/container-app-environment.bicep` file to enhance the handling of Log Analytics Workspace scopes. The update ensures that the scope includes the subscription ID extracted from the `logAnalyticsResourceId`.

### Changes related to Log Analytics Workspace scope handling:
* [`infra/modules/container-app-environment.bicep`](diffhunk://#diff-d53e4689b200ce2579c12caf301fbc869a9076ccf62d9fc0958c1b7e1013dd83R13-R19): Added a variable `existingLawSubscription` to extract the subscription ID from `logAnalyticsResourceId`. Updated the `scope` property of the `logAnalyticsWorkspace` resource to include both the subscription ID and resource group, improving accuracy in resource targeting.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
