### PR TITLE
fix: Disable Zone Redundant for all locations

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -861,7 +861,7 @@ module aiFoundryStorageAccount 'br/public:avm/res/storage/storage-account:0.18.2
       diagnosticSettings: [{ workspaceResourceId: logAnalyticsWorkspaceId }]
     }
     publicNetworkAccess: virtualNetworkEnabled ? 'Disabled' : 'Enabled'
-    allowBlobPublicAccess: virtualNetworkEnabled ? false : true
+    allowBlobPublicAccess: false
     privateEndpoints: virtualNetworkEnabled
       ? map(items(storageAccountPrivateDnsZones), zone => {
           name: 'pep-${zone.value}-${aiFoundryStorageAccountResourceName}'
@@ -1036,6 +1036,7 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.12.0' = if (co
       {
         locationName: cosmosDbAccountConfiguration.?location ?? solutionLocation
         failoverPriority: 0
+        isZoneRedundant: false
       }
     ]
     capabilitiesToAdd: [
@@ -1073,7 +1074,7 @@ module containerAppEnvironment 'modules/container-app-environment.bicep' = if (c
     location: containerAppEnvironmentConfiguration.?location ?? solutionLocation
     logAnalyticsResourceId: logAnalyticsWorkspaceId
     publicNetworkAccess: 'Enabled'
-    zoneRedundant: virtualNetworkEnabled ? true : false
+    zoneRedundant: false
     applicationInsightsConnectionString: applicationInsights.outputs.connectionString
     enableTelemetry: enableTelemetry
     subnetResourceId: virtualNetworkEnabled


### PR DESCRIPTION
This pull request makes several updates to the `infra/main.bicep` file to enhance security and simplify configurations. The changes primarily involve disabling public access and zone redundancy for various resources.

### Security Enhancements:
Updated `allowBlobPublicAccess` to always be `false`, regardless of the `virtualNetworkEnabled` setting, ensuring no public access to storage blobs.

### Configuration Simplifications:
Added `isZoneRedundant: false` to explicitly disable zone redundancy for Cosmos DB accounts.
Updated `zoneRedundant` to always be `false`, simplifying the configuration for container app environments.## Purpose


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->