### PR TITLE
fix: Macae bug fixes for tooltip

### DIFF
--- a/src/frontend/src/components/content/TaskDetails.tsx
+++ b/src/frontend/src/components/content/TaskDetails.tsx
@@ -149,7 +149,7 @@ const TaskDetails: React.FC<TaskDetailsProps> = ({
                   <div className="task-details-action-buttons">
                     {step.human_approval_status !== "accepted" &&
                       step.human_approval_status !== "rejected" && (
-                        <>             <Tooltip relationship="label" content="Approve">
+                        <>             <Tooltip relationship="label" content={canInteract?"Approve":"You must first provide feedback to the planner"}>
                           <Button
                             icon={<Checkmark20Regular />}
                             appearance="subtle"
@@ -166,7 +166,7 @@ const TaskDetails: React.FC<TaskDetailsProps> = ({
                           />
                         </Tooltip>
 
-                          <Tooltip relationship="label" content="Reject">
+                          <Tooltip relationship="label" content={canInteract?"Reject":"You must first provide feedback to the planner"}>
                             <Button
                               icon={<Dismiss20Regular />}
                               appearance="subtle"


### PR DESCRIPTION
## Purpose
This pull request updates the `TaskDetails` component in the `src/frontend/src/components/content/TaskDetails.tsx` file to improve user interaction by dynamically adjusting tooltip content based on the `canInteract` state.

Enhancements to user interaction:

* Updated the tooltip for the "Approve" button to display "You must first provide feedback to the planner" when `canInteract` is `false`, enhancing clarity for users who cannot interact yet.
* Updated the tooltip for the "Reject" button to display "You must first provide feedback to the planner" when `canInteract` is `false`, ensuring consistent messaging across action buttons.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->