### PR TITLE
docs: Removed outdated container publishing instructions

### DIFF
--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -206,43 +206,9 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
 
 5. Once the deployment has completed successfully, open the [Azure Portal](https://portal.azure.com/), go to the deployed resource group, find the App Service, and get the app URL from `Default domain`.
 
-6. If you are done trying out the application, you can delete the resources by running `azd down`.
+6. When Deployment is complete, follow steps in [Set Up Authentication in Azure App Service](../docs/azure_app_service_auth_setup.md) to add app authentication to your web app running on Azure App Service
 
-### Publishing Local Build Container to Azure Container Registry
-
-If you need to rebuild the source code and push the updated container to the deployed Azure Container Registry, follow these steps:
-
-1. Set the environment variable `USE_LOCAL_BUILD` to `True`:
-
-   - **Linux/macOS**:
-
-     ```bash
-     export USE_LOCAL_BUILD=True
-     ```
-
-   - **Windows (PowerShell)**:
-     ```powershell
-     $env:USE_LOCAL_BUILD = $true
-     ```
-
-2. Run the `az login` command
-
-   ```bash
-   az login
-   ```
-
-3. Run the `azd up` command again to rebuild and push the updated container:
-   ```bash
-   azd up
-   ```
-
-This will rebuild the source code, package it into a container, and push it to the Azure Container Registry associated with your deployment.
-
-This guide provides step-by-step instructions for deploying your application using Azure Container Registry (ACR) and Azure Container Apps.
-
-There are several ways to deploy the solution. You can deploy to run in Azure in one click, or manually, or you can deploy locally.
-
-When Deployment is complete, follow steps in [Set Up Authentication in Azure App Service](../docs/azure_app_service_auth_setup.md) to add app authentication to your web app running on Azure App Service
+7. If you are done trying out the application, you can delete the resources by running `azd down`.
 
 # Local setup
 


### PR DESCRIPTION
## Purpose
This pull request updates the deployment documentation to streamline the post-deployment steps and removes instructions for publishing a local build container to Azure Container Registry. The changes focus on clarifying the authentication setup process and simplifying the guide for users deploying on Azure App Service.

Documentation updates:

* Changed step 6 in `docs/DeploymentGuide.md` to direct users to follow the authentication setup guide after deployment, improving clarity on required post-deployment actions.
* Removed the section detailing how to publish a local build container to Azure Container Registry, reducing complexity and focusing the guide on standard deployment scenarios.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```