### PR TITLE
docs: make deployment regions user-selectable in CustomizingAzdParameters.md

### DIFF
--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -9,8 +9,8 @@ By default this template will use the environment name as the prefix to prevent 
 | Name                            | Type   | Default Value     | Purpose                                                                                             |
 | ------------------------------- | ------ | ----------------- | --------------------------------------------------------------------------------------------------- |
 | `AZURE_ENV_NAME`                | string | `macae`           | Used as a prefix for all resource names to ensure uniqueness across environments.                   |
-| `AZURE_LOCATION`                | string | `swedencentral`   | Location of the Azure resources. Controls where the infrastructure will be deployed.                |
-| `AZURE_ENV_OPENAI_LOCATION`     | string | `swedencentral`   | Specifies the region for OpenAI resource deployment.                                                |
+| `AZURE_LOCATION`                | string | `<User selects during deployment>`   | Location of the Azure resources. Controls where the infrastructure will be deployed.                |
+| `AZURE_ENV_OPENAI_LOCATION`     | string | `<User selects during deployment>`   | Specifies the region for OpenAI resource deployment.                                                |
 | `AZURE_ENV_MODEL_DEPLOYMENT_TYPE` | string | `GlobalStandard` | Defines the deployment type for the AI model (e.g., Standard, GlobalStandard).                     |
 | `AZURE_ENV_MODEL_NAME`          | string | `gpt-4o`          | Specifies the name of the GPT model to be deployed.                                                |
 | `AZURE_ENV_FOUNDRY_PROJECT_ID`          | string | `<Existing Workspace Id>`          | Set this if you want to reuse an AI Foundry Project instead of creating a new one.                                                |                        


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Replaced hardcoded region values ("swedencentral") with "<User selects during deployment>" in docs/CustomizingAzdParameters.md for:
- AZURE_LOCATION
- AZURE_ENV_OPENAI_LOCATION

This change makes the documentation generic so deployment region can be chosen at deploy time.


This ensures documentation reflects the current default regions used during deployment.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->