### PR TITLE
fix: Merging dev to main for the demo env tool string length issue

### DIFF
--- a/src/backend/kernel_agents/planner_agent.py
+++ b/src/backend/kernel_agents/planner_agent.py
@@ -536,7 +536,7 @@ class PlannerAgent(BaseAgent):
             if agent_name in self._available_agents:
                 tools_list.append(tools)
 
-        tools_str = str(tools_list)
+        tools_str = tools_list
 
         # Return a dictionary with template variables
         return {
@@ -568,7 +568,6 @@ class PlannerAgent(BaseAgent):
             These agents have access to the following functions:
             {{$tools_str}}
 
-            The first step of your plan should be to ask the user for any additional information required to progress the rest of steps planned.
 
             Only use the functions provided as part of your plan. If the task is not possible with the agents and tools provided, create a step with the agent of type Human and mark the overall status as completed.
 

--- a/src/backend/kernel_tools/generic_tools.py
+++ b/src/backend/kernel_tools/generic_tools.py
@@ -130,4 +130,4 @@ class GenericTools:
                 tools_list.append(tool_entry)
 
         # Return the JSON string representation
-        return json.dumps(tools_list, ensure_ascii=False, indent=2)
+        return json.dumps(tools_list, ensure_ascii=False)

--- a/src/backend/kernel_tools/hr_tools.py
+++ b/src/backend/kernel_tools/hr_tools.py
@@ -119,45 +119,45 @@ class HrTools:
             f"{HrTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Process a leave request for an employee.")
-    async def process_leave_request(
-        employee_name: str, leave_type: str, start_date: str, end_date: str
-    ) -> str:
-        return (
-            f"##### Leave Request Processed\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Leave Type:** {leave_type}\n"
-            f"**Start Date:** {start_date}\n"
-            f"**End Date:** {end_date}\n\n"
-            f"Your leave request has been processed. "
-            f"Please ensure you have completed any necessary handover tasks before your leave.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Process a leave request for an employee.")
+    # async def process_leave_request(
+    #     employee_name: str, leave_type: str, start_date: str, end_date: str
+    # ) -> str:
+    #     return (
+    #         f"##### Leave Request Processed\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Leave Type:** {leave_type}\n"
+    #         f"**Start Date:** {start_date}\n"
+    #         f"**End Date:** {end_date}\n\n"
+    #         f"Your leave request has been processed. "
+    #         f"Please ensure you have completed any necessary handover tasks before your leave.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Update company policies.")
-    async def update_policies(policy_name: str, policy_content: str) -> str:
-        return (
-            f"##### Policy Updated\n"
-            f"**Policy Name:** {policy_name}\n\n"
-            f"The policy has been updated with the following content:\n\n"
-            f"{policy_content}\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Update company policies.")
+    # async def update_policies(policy_name: str, policy_content: str) -> str:
+    #     return (
+    #         f"##### Policy Updated\n"
+    #         f"**Policy Name:** {policy_name}\n\n"
+    #         f"The policy has been updated with the following content:\n\n"
+    #         f"{policy_content}\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(
-        description="Conduct an exit interview for an employee leaving the company."
-    )
-    async def conduct_exit_interview(employee_name: str) -> str:
-        return (
-            f"##### Exit Interview Conducted\n"
-            f"**Employee Name:** {employee_name}\n\n"
-            f"The exit interview has been conducted. "
-            f"Thank you for your feedback and contributions to the company.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(
+    #     description="Conduct an exit interview for an employee leaving the company."
+    # )
+    # async def conduct_exit_interview(employee_name: str) -> str:
+    #     return (
+    #         f"##### Exit Interview Conducted\n"
+    #         f"**Employee Name:** {employee_name}\n\n"
+    #         f"The exit interview has been conducted. "
+    #         f"Thank you for your feedback and contributions to the company.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Verify employment status for an employee.")
@@ -169,39 +169,39 @@ class HrTools:
             f"{HrTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Schedule a performance review for an employee.")
-    async def schedule_performance_review(employee_name: str, date: str) -> str:
-        return (
-            f"##### Performance Review Scheduled\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Date:** {date}\n\n"
-            f"Your performance review has been scheduled. "
-            f"Please prepare any necessary documents and be ready for the review.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Schedule a performance review for an employee.")
+    # async def schedule_performance_review(employee_name: str, date: str) -> str:
+    #     return (
+    #         f"##### Performance Review Scheduled\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Date:** {date}\n\n"
+    #         f"Your performance review has been scheduled. "
+    #         f"Please prepare any necessary documents and be ready for the review.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Approve an expense claim for an employee.")
-    async def approve_expense_claim(employee_name: str, claim_amount: float) -> str:
-        return (
-            f"##### Expense Claim Approved\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Claim Amount:** ${claim_amount:.2f}\n\n"
-            f"Your expense claim has been approved. "
-            f"The amount will be reimbursed in your next payroll.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Approve an expense claim for an employee.")
+    # async def approve_expense_claim(employee_name: str, claim_amount: float) -> str:
+    #     return (
+    #         f"##### Expense Claim Approved\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Claim Amount:** ${claim_amount:.2f}\n\n"
+    #         f"Your expense claim has been approved. "
+    #         f"The amount will be reimbursed in your next payroll.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Send a company-wide announcement.")
-    async def send_company_announcement(subject: str, content: str) -> str:
-        return (
-            f"##### Company Announcement\n"
-            f"**Subject:** {subject}\n\n"
-            f"{content}\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Send a company-wide announcement.")
+    # async def send_company_announcement(subject: str, content: str) -> str:
+    #     return (
+    #         f"##### Company Announcement\n"
+    #         f"**Subject:** {subject}\n\n"
+    #         f"{content}\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Retrieve the employee directory.")
@@ -252,39 +252,39 @@ class HrTools:
             f"{HrTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Manage an employee transfer between departments.")
-    async def manage_employee_transfer(employee_name: str, new_department: str) -> str:
-        return (
-            f"##### Employee Transfer\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**New Department:** {new_department}\n\n"
-            f"The transfer has been successfully processed. "
-            f"{employee_name} is now part of the {new_department} department.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage an employee transfer between departments.")
+    # async def manage_employee_transfer(employee_name: str, new_department: str) -> str:
+    #     return (
+    #         f"##### Employee Transfer\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**New Department:** {new_department}\n\n"
+    #         f"The transfer has been successfully processed. "
+    #         f"{employee_name} is now part of the {new_department} department.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Track attendance for an employee.")
-    async def track_employee_attendance(employee_name: str) -> str:
-        return (
-            f"##### Attendance Tracked\n"
-            f"**Employee Name:** {employee_name}\n\n"
-            f"The attendance for {employee_name} has been successfully tracked.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Track attendance for an employee.")
+    # async def track_employee_attendance(employee_name: str) -> str:
+    #     return (
+    #         f"##### Attendance Tracked\n"
+    #         f"**Employee Name:** {employee_name}\n\n"
+    #         f"The attendance for {employee_name} has been successfully tracked.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Organize a health and wellness program.")
-    async def organize_wellness_program(program_name: str, date: str) -> str:
-        return (
-            f"##### Health and Wellness Program Organized\n"
-            f"**Program Name:** {program_name}\n"
-            f"**Date:** {date}\n\n"
-            f"The health and wellness program has been successfully organized. "
-            f"Please join us on {date} for an informative and engaging session.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Organize a health and wellness program.")
+    # async def organize_wellness_program(program_name: str, date: str) -> str:
+    #     return (
+    #         f"##### Health and Wellness Program Organized\n"
+    #         f"**Program Name:** {program_name}\n"
+    #         f"**Date:** {date}\n\n"
+    #         f"The health and wellness program has been successfully organized. "
+    #         f"Please join us on {date} for an informative and engaging session.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(
@@ -299,73 +299,73 @@ class HrTools:
             f"{HrTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Manage the retirement plan for an employee.")
-    async def manage_retirement_plan(employee_name: str) -> str:
-        return (
-            f"##### Retirement Plan Managed\n"
-            f"**Employee Name:** {employee_name}\n\n"
-            f"The retirement plan for {employee_name} has been successfully managed.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage the retirement plan for an employee.")
+    # async def manage_retirement_plan(employee_name: str) -> str:
+    #     return (
+    #         f"##### Retirement Plan Managed\n"
+    #         f"**Employee Name:** {employee_name}\n\n"
+    #         f"The retirement plan for {employee_name} has been successfully managed.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Handle an overtime request for an employee.")
-    async def handle_overtime_request(employee_name: str, hours: float) -> str:
-        return (
-            f"##### Overtime Request Handled\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Hours:** {hours}\n\n"
-            f"The overtime request for {employee_name} has been successfully handled.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Handle an overtime request for an employee.")
+    # async def handle_overtime_request(employee_name: str, hours: float) -> str:
+    #     return (
+    #         f"##### Overtime Request Handled\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Hours:** {hours}\n\n"
+    #         f"The overtime request for {employee_name} has been successfully handled.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Issue a bonus to an employee.")
-    async def issue_bonus(employee_name: str, amount: float) -> str:
-        return (
-            f"##### Bonus Issued\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Amount:** ${amount:.2f}\n\n"
-            f"A bonus of ${amount:.2f} has been issued to {employee_name}.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Issue a bonus to an employee.")
+    # async def issue_bonus(employee_name: str, amount: float) -> str:
+    #     return (
+    #         f"##### Bonus Issued\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Amount:** ${amount:.2f}\n\n"
+    #         f"A bonus of ${amount:.2f} has been issued to {employee_name}.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Schedule a wellness check for an employee.")
-    async def schedule_wellness_check(employee_name: str, date: str) -> str:
-        return (
-            f"##### Wellness Check Scheduled\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Date:** {date}\n\n"
-            f"A wellness check has been scheduled for {employee_name} on {date}.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Schedule a wellness check for an employee.")
+    # async def schedule_wellness_check(employee_name: str, date: str) -> str:
+    #     return (
+    #         f"##### Wellness Check Scheduled\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Date:** {date}\n\n"
+    #         f"A wellness check has been scheduled for {employee_name} on {date}.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Handle a suggestion made by an employee.")
-    async def handle_employee_suggestion(employee_name: str, suggestion: str) -> str:
-        return (
-            f"##### Employee Suggestion Handled\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Suggestion:** {suggestion}\n\n"
-            f"The suggestion from {employee_name} has been successfully handled.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Handle a suggestion made by an employee.")
+    # async def handle_employee_suggestion(employee_name: str, suggestion: str) -> str:
+    #     return (
+    #         f"##### Employee Suggestion Handled\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Suggestion:** {suggestion}\n\n"
+    #         f"The suggestion from {employee_name} has been successfully handled.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Update privileges for an employee.")
-    async def update_employee_privileges(
-        employee_name: str, privilege: str, status: str
-    ) -> str:
-        return (
-            f"##### Employee Privileges Updated\n"
-            f"**Employee Name:** {employee_name}\n"
-            f"**Privilege:** {privilege}\n"
-            f"**Status:** {status}\n\n"
-            f"The privileges for {employee_name} have been successfully updated.\n"
-            f"{HrTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Update privileges for an employee.")
+    # async def update_employee_privileges(
+    #     employee_name: str, privilege: str, status: str
+    # ) -> str:
+    #     return (
+    #         f"##### Employee Privileges Updated\n"
+    #         f"**Employee Name:** {employee_name}\n"
+    #         f"**Privilege:** {privilege}\n"
+    #         f"**Status:** {status}\n\n"
+    #         f"The privileges for {employee_name} have been successfully updated.\n"
+    #         f"{HrTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Send a welcome email to an address.")
@@ -485,4 +485,4 @@ class HrTools:
                 tools_list.append(tool_entry)
 
         # Return the JSON string representation
-        return json.dumps(tools_list, ensure_ascii=False, indent=2)
+        return json.dumps(tools_list, ensure_ascii=False)

--- a/src/backend/kernel_tools/marketing_tools.py
+++ b/src/backend/kernel_tools/marketing_tools.py
@@ -37,24 +37,24 @@ class MarketingTools:
     async def plan_advertising_budget(campaign_name: str, total_budget: float) -> str:
         return f"Advertising budget planned for campaign '{campaign_name}' with a total budget of ${total_budget:.2f}."
 
-    @staticmethod
-    @kernel_function(description="Conduct a customer survey on a specific topic.")
-    async def conduct_customer_survey(survey_topic: str, target_group: str) -> str:
-        return (
-            f"Customer survey on '{survey_topic}' conducted targeting '{target_group}'."
-        )
+    # @staticmethod
+    # @kernel_function(description="Conduct a customer survey on a specific topic.")
+    # async def conduct_customer_survey(survey_topic: str, target_group: str) -> str:
+    #     return (
+    #         f"Customer survey on '{survey_topic}' conducted targeting '{target_group}'."
+    #     )
 
     @staticmethod
     @kernel_function(description="Perform a competitor analysis.")
     async def perform_competitor_analysis(competitor_name: str) -> str:
         return f"Competitor analysis performed on '{competitor_name}'."
 
-    @staticmethod
-    @kernel_function(description="Schedule a marketing event.")
-    async def schedule_marketing_event(
-        event_name: str, date: str, location: str
-    ) -> str:
-        return f"Marketing event '{event_name}' scheduled on {date} at {location}."
+    # @staticmethod
+    # @kernel_function(description="Schedule a marketing event.")
+    # async def schedule_marketing_event(
+    #     event_name: str, date: str, location: str
+    # ) -> str:
+    #     return f"Marketing event '{event_name}' scheduled on {date} at {location}."
 
     @staticmethod
     @kernel_function(description="Design promotional material for a campaign.")
@@ -68,30 +68,30 @@ class MarketingTools:
     async def manage_email_marketing(campaign_name: str, email_list_size: int) -> str:
         return f"Email marketing managed for campaign '{campaign_name}' targeting {email_list_size} recipients."
 
-    @staticmethod
-    @kernel_function(description="Track the performance of a campaign.")
-    async def track_campaign_performance(campaign_name: str) -> str:
-        return f"Performance of campaign '{campaign_name}' tracked."
+    # @staticmethod
+    # @kernel_function(description="Track the performance of a campaign.")
+    # async def track_campaign_performance(campaign_name: str) -> str:
+    #     return f"Performance of campaign '{campaign_name}' tracked."
 
     @staticmethod
     @kernel_function(description="Coordinate a campaign with the sales team.")
     async def coordinate_with_sales_team(campaign_name: str) -> str:
         return f"Campaign '{campaign_name}' coordinated with the sales team."
 
-    @staticmethod
-    @kernel_function(description="Develop a brand strategy.")
-    async def develop_brand_strategy(brand_name: str) -> str:
-        return f"Brand strategy developed for '{brand_name}'."
+    # @staticmethod
+    # @kernel_function(description="Develop a brand strategy.")
+    # async def develop_brand_strategy(brand_name: str) -> str:
+    #     return f"Brand strategy developed for '{brand_name}'."
 
-    @staticmethod
-    @kernel_function(description="Create a content calendar for a specific month.")
-    async def create_content_calendar(month: str) -> str:
-        return f"Content calendar for '{month}' created."
+    # @staticmethod
+    # @kernel_function(description="Create a content calendar for a specific month.")
+    # async def create_content_calendar(month: str) -> str:
+    #     return f"Content calendar for '{month}' created."
 
-    @staticmethod
-    @kernel_function(description="Update content on a specific website page.")
-    async def update_website_content(page_name: str) -> str:
-        return f"Website content on page '{page_name}' updated."
+    # @staticmethod
+    # @kernel_function(description="Update content on a specific website page.")
+    # async def update_website_content(page_name: str) -> str:
+    #     return f"Website content on page '{page_name}' updated."
 
     @staticmethod
     @kernel_function(description="Plan a product launch.")
@@ -105,27 +105,27 @@ class MarketingTools:
     async def generate_press_release(key_information_for_press_release: str) -> str:
         return f"Look through the conversation history. Identify the content. Now you must generate a press release based on this content {key_information_for_press_release}. Make it approximately 2 paragraphs."
 
-    @staticmethod
-    @kernel_function(description="Conduct market research on a specific topic.")
-    async def conduct_market_research(research_topic: str) -> str:
-        return f"Market research conducted on '{research_topic}'."
+    # @staticmethod
+    # @kernel_function(description="Conduct market research on a specific topic.")
+    # async def conduct_market_research(research_topic: str) -> str:
+    #     return f"Market research conducted on '{research_topic}'."
 
-    @staticmethod
-    @kernel_function(description="Handle customer feedback.")
-    async def handle_customer_feedback(feedback_details: str) -> str:
-        return f"Customer feedback handled: {feedback_details}."
+    # @staticmethod
+    # @kernel_function(description="Handle customer feedback.")
+    # async def handle_customer_feedback(feedback_details: str) -> str:
+    #     return f"Customer feedback handled: {feedback_details}."
 
     @staticmethod
     @kernel_function(description="Generate a marketing report for a campaign.")
     async def generate_marketing_report(campaign_name: str) -> str:
         return f"Marketing report generated for campaign '{campaign_name}'."
 
-    @staticmethod
-    @kernel_function(description="Manage a social media account.")
-    async def manage_social_media_account(platform: str, account_name: str) -> str:
-        return (
-            f"Social media account '{account_name}' on platform '{platform}' managed."
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage a social media account.")
+    # async def manage_social_media_account(platform: str, account_name: str) -> str:
+    #     return (
+    #         f"Social media account '{account_name}' on platform '{platform}' managed."
+    #     )
 
     @staticmethod
     @kernel_function(description="Create a video advertisement.")
@@ -134,15 +134,15 @@ class MarketingTools:
             f"Video advertisement '{content_title}' created for platform '{platform}'."
         )
 
-    @staticmethod
-    @kernel_function(description="Conduct a focus group study.")
-    async def conduct_focus_group(study_topic: str, participants: int) -> str:
-        return f"Focus group study on '{study_topic}' conducted with {participants} participants."
+    # @staticmethod
+    # @kernel_function(description="Conduct a focus group study.")
+    # async def conduct_focus_group(study_topic: str, participants: int) -> str:
+    #     return f"Focus group study on '{study_topic}' conducted with {participants} participants."
 
-    @staticmethod
-    @kernel_function(description="Update brand guidelines.")
-    async def update_brand_guidelines(brand_name: str, guidelines: str) -> str:
-        return f"Brand guidelines for '{brand_name}' updated."
+    # @staticmethod
+    # @kernel_function(description="Update brand guidelines.")
+    # async def update_brand_guidelines(brand_name: str, guidelines: str) -> str:
+    #     return f"Brand guidelines for '{brand_name}' updated."
 
     @staticmethod
     @kernel_function(description="Handle collaboration with an influencer.")
@@ -151,30 +151,30 @@ class MarketingTools:
     ) -> str:
         return f"Collaboration with influencer '{influencer_name}' for campaign '{campaign_name}' handled."
 
-    @staticmethod
-    @kernel_function(description="Analyze customer behavior in a specific segment.")
-    async def analyze_customer_behavior(segment: str) -> str:
-        return f"Customer behavior in segment '{segment}' analyzed."
+    # @staticmethod
+    # @kernel_function(description="Analyze customer behavior in a specific segment.")
+    # async def analyze_customer_behavior(segment: str) -> str:
+    #     return f"Customer behavior in segment '{segment}' analyzed."
 
-    @staticmethod
-    @kernel_function(description="Manage a customer loyalty program.")
-    async def manage_loyalty_program(program_name: str, members: int) -> str:
-        return f"Loyalty program '{program_name}' managed with {members} members."
+    # @staticmethod
+    # @kernel_function(description="Manage a customer loyalty program.")
+    # async def manage_loyalty_program(program_name: str, members: int) -> str:
+    #     return f"Loyalty program '{program_name}' managed with {members} members."
 
     @staticmethod
     @kernel_function(description="Develop a content strategy.")
     async def develop_content_strategy(strategy_name: str) -> str:
         return f"Content strategy '{strategy_name}' developed."
 
-    @staticmethod
-    @kernel_function(description="Create an infographic.")
-    async def create_infographic(content_title: str) -> str:
-        return f"Infographic '{content_title}' created."
+    # @staticmethod
+    # @kernel_function(description="Create an infographic.")
+    # async def create_infographic(content_title: str) -> str:
+    #     return f"Infographic '{content_title}' created."
 
-    @staticmethod
-    @kernel_function(description="Schedule a webinar.")
-    async def schedule_webinar(webinar_title: str, date: str, platform: str) -> str:
-        return f"Webinar '{webinar_title}' scheduled on {date} via {platform}."
+    # @staticmethod
+    # @kernel_function(description="Schedule a webinar.")
+    # async def schedule_webinar(webinar_title: str, date: str, platform: str) -> str:
+    #     return f"Webinar '{webinar_title}' scheduled on {date} via {platform}."
 
     @staticmethod
     @kernel_function(description="Manage online reputation for a brand.")
@@ -186,10 +186,10 @@ class MarketingTools:
     async def run_email_ab_testing(campaign_name: str) -> str:
         return f"A/B testing for email campaign '{campaign_name}' run."
 
-    @staticmethod
-    @kernel_function(description="Create a podcast episode.")
-    async def create_podcast_episode(series_name: str, episode_title: str) -> str:
-        return f"Podcast episode '{episode_title}' for series '{series_name}' created."
+    # @staticmethod
+    # @kernel_function(description="Create a podcast episode.")
+    # async def create_podcast_episode(series_name: str, episode_title: str) -> str:
+    #     return f"Podcast episode '{episode_title}' for series '{series_name}' created."
 
     @staticmethod
     @kernel_function(description="Manage an affiliate marketing program.")
@@ -198,20 +198,20 @@ class MarketingTools:
             f"Affiliate program '{program_name}' managed with {affiliates} affiliates."
         )
 
-    @staticmethod
-    @kernel_function(description="Generate lead magnets.")
-    async def generate_lead_magnets(content_title: str) -> str:
-        return f"Lead magnet '{content_title}' generated."
+    # @staticmethod
+    # @kernel_function(description="Generate lead magnets.")
+    # async def generate_lead_magnets(content_title: str) -> str:
+    #     return f"Lead magnet '{content_title}' generated."
 
-    @staticmethod
-    @kernel_function(description="Organize participation in a trade show.")
-    async def organize_trade_show(booth_number: str, event_name: str) -> str:
-        return f"Trade show '{event_name}' organized at booth number '{booth_number}'."
+    # @staticmethod
+    # @kernel_function(description="Organize participation in a trade show.")
+    # async def organize_trade_show(booth_number: str, event_name: str) -> str:
+    #     return f"Trade show '{event_name}' organized at booth number '{booth_number}'."
 
-    @staticmethod
-    @kernel_function(description="Manage a customer retention program.")
-    async def manage_retention_program(program_name: str) -> str:
-        return f"Customer retention program '{program_name}' managed."
+    # @staticmethod
+    # @kernel_function(description="Manage a customer retention program.")
+    # async def manage_retention_program(program_name: str) -> str:
+    #     return f"Customer retention program '{program_name}' managed."
 
     @staticmethod
     @kernel_function(description="Run a pay-per-click (PPC) campaign.")
@@ -223,25 +223,25 @@ class MarketingTools:
     async def create_case_study(case_title: str, client_name: str) -> str:
         return f"Case study '{case_title}' for client '{client_name}' created."
 
-    @staticmethod
-    @kernel_function(description="Generate lead nurturing emails.")
-    async def generate_lead_nurturing_emails(sequence_name: str, steps: int) -> str:
-        return f"Lead nurturing email sequence '{sequence_name}' generated with {steps} steps."
+    # @staticmethod
+    # @kernel_function(description="Generate lead nurturing emails.")
+    # async def generate_lead_nurturing_emails(sequence_name: str, steps: int) -> str:
+    #     return f"Lead nurturing email sequence '{sequence_name}' generated with {steps} steps."
 
-    @staticmethod
-    @kernel_function(description="Manage crisis communication.")
-    async def manage_crisis_communication(crisis_situation: str) -> str:
-        return f"Crisis communication managed for situation '{crisis_situation}'."
+    # @staticmethod
+    # @kernel_function(description="Manage crisis communication.")
+    # async def manage_crisis_communication(crisis_situation: str) -> str:
+    #     return f"Crisis communication managed for situation '{crisis_situation}'."
 
-    @staticmethod
-    @kernel_function(description="Create interactive content.")
-    async def create_interactive_content(content_title: str) -> str:
-        return f"Interactive content '{content_title}' created."
+    # @staticmethod
+    # @kernel_function(description="Create interactive content.")
+    # async def create_interactive_content(content_title: str) -> str:
+    #     return f"Interactive content '{content_title}' created."
 
-    @staticmethod
-    @kernel_function(description="Handle media relations.")
-    async def handle_media_relations(media_outlet: str) -> str:
-        return f"Media relations handled with '{media_outlet}'."
+    # @staticmethod
+    # @kernel_function(description="Handle media relations.")
+    # async def handle_media_relations(media_outlet: str) -> str:
+    #     return f"Media relations handled with '{media_outlet}'."
 
     @staticmethod
     @kernel_function(description="Create a testimonial video.")
@@ -253,10 +253,10 @@ class MarketingTools:
     async def manage_event_sponsorship(event_name: str, sponsor_name: str) -> str:
         return f"Event sponsorship for '{event_name}' managed with sponsor '{sponsor_name}'."
 
-    @staticmethod
-    @kernel_function(description="Optimize a specific stage of the conversion funnel.")
-    async def optimize_conversion_funnel(stage: str) -> str:
-        return f"Conversion funnel stage '{stage}' optimized."
+    # @staticmethod
+    # @kernel_function(description="Optimize a specific stage of the conversion funnel.")
+    # async def optimize_conversion_funnel(stage: str) -> str:
+    #     return f"Conversion funnel stage '{stage}' optimized."
 
     # ToDo: Seems to be a bug in SK when processing functions with list parameters
     @staticmethod
@@ -360,7 +360,7 @@ class MarketingTools:
                 tools_list.append(tool_entry)
 
         # Return the JSON string representation
-        return json.dumps(tools_list, ensure_ascii=False, indent=2)
+        return json.dumps(tools_list, ensure_ascii=False)
 
     # This function does NOT have the kernel_function annotation
     # because it's meant for introspection rather than being exposed as a tool

--- a/src/backend/kernel_tools/procurement_tools.py
+++ b/src/backend/kernel_tools/procurement_tools.py
@@ -49,60 +49,60 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Process a purchase order.")
-    async def process_purchase_order(po_number: str) -> str:
-        return (
-            f"##### Purchase Order Processed\n"
-            f"**PO Number:** {po_number}\n\n"
-            f"Purchase Order {po_number} has been processed.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Process a purchase order.")
+    # async def process_purchase_order(po_number: str) -> str:
+    #     return (
+    #         f"##### Purchase Order Processed\n"
+    #         f"**PO Number:** {po_number}\n\n"
+    #         f"Purchase Order {po_number} has been processed.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Initiate contract negotiation with a vendor.")
-    async def initiate_contract_negotiation(
-        vendor_name: str, contract_details: str
-    ) -> str:
-        return (
-            f"##### Contract Negotiation Initiated\n"
-            f"**Vendor:** {vendor_name}\n"
-            f"**Contract Details:** {contract_details}\n\n"
-            f"Contract negotiation initiated with {vendor_name}: {contract_details}\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Initiate contract negotiation with a vendor.")
+    # async def initiate_contract_negotiation(
+    #     vendor_name: str, contract_details: str
+    # ) -> str:
+    #     return (
+    #         f"##### Contract Negotiation Initiated\n"
+    #         f"**Vendor:** {vendor_name}\n"
+    #         f"**Contract Details:** {contract_details}\n\n"
+    #         f"Contract negotiation initiated with {vendor_name}: {contract_details}\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Approve an invoice for payment.")
-    async def approve_invoice(invoice_number: str) -> str:
-        return (
-            f"##### Invoice Approved\n"
-            f"**Invoice Number:** {invoice_number}\n\n"
-            f"Invoice {invoice_number} approved for payment.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Approve an invoice for payment.")
+    # async def approve_invoice(invoice_number: str) -> str:
+    #     return (
+    #         f"##### Invoice Approved\n"
+    #         f"**Invoice Number:** {invoice_number}\n\n"
+    #         f"Invoice {invoice_number} approved for payment.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Track the status of an order.")
-    async def track_order(order_number: str) -> str:
-        return (
-            f"##### Order Tracking\n"
-            f"**Order Number:** {order_number}\n"
-            f"**Status:** In Transit\n\n"
-            f"Order {order_number} is currently in transit.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Track the status of an order.")
+    # async def track_order(order_number: str) -> str:
+    #     return (
+    #         f"##### Order Tracking\n"
+    #         f"**Order Number:** {order_number}\n"
+    #         f"**Status:** In Transit\n\n"
+    #         f"Order {order_number} is currently in transit.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Manage relationships with vendors.")
-    async def manage_vendor_relationship(vendor_name: str, action: str) -> str:
-        return (
-            f"##### Vendor Relationship Update\n"
-            f"**Vendor:** {vendor_name}\n"
-            f"**Action:** {action}\n\n"
-            f"Vendor relationship with {vendor_name} has been {action}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage relationships with vendors.")
+    # async def manage_vendor_relationship(vendor_name: str, action: str) -> str:
+    #     return (
+    #         f"##### Vendor Relationship Update\n"
+    #         f"**Vendor:** {vendor_name}\n"
+    #         f"**Action:** {action}\n\n"
+    #         f"Vendor relationship with {vendor_name} has been {action}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Update a procurement policy.")
@@ -114,25 +114,25 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Generate a procurement report.")
-    async def generate_procurement_report(report_type: str) -> str:
-        return (
-            f"##### Procurement Report Generated\n"
-            f"**Report Type:** {report_type}\n\n"
-            f"Generated {report_type} procurement report.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Generate a procurement report.")
+    # async def generate_procurement_report(report_type: str) -> str:
+    #     return (
+    #         f"##### Procurement Report Generated\n"
+    #         f"**Report Type:** {report_type}\n\n"
+    #         f"Generated {report_type} procurement report.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Evaluate the performance of a supplier.")
-    async def evaluate_supplier_performance(supplier_name: str) -> str:
-        return (
-            f"##### Supplier Performance Evaluation\n"
-            f"**Supplier:** {supplier_name}\n\n"
-            f"Performance evaluation for supplier {supplier_name} completed.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Evaluate the performance of a supplier.")
+    # async def evaluate_supplier_performance(supplier_name: str) -> str:
+    #     return (
+    #         f"##### Supplier Performance Evaluation\n"
+    #         f"**Supplier:** {supplier_name}\n\n"
+    #         f"Performance evaluation for supplier {supplier_name} completed.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Handle the return of procured items.")
@@ -168,59 +168,59 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Recommend sourcing options for an item.")
-    async def recommend_sourcing_options(item_name: str) -> str:
-        return (
-            f"##### Sourcing Options\n"
-            f"**Item:** {item_name}\n\n"
-            f"Sourcing options for {item_name} have been provided.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Recommend sourcing options for an item.")
+    # async def recommend_sourcing_options(item_name: str) -> str:
+    #     return (
+    #         f"##### Sourcing Options\n"
+    #         f"**Item:** {item_name}\n\n"
+    #         f"Sourcing options for {item_name} have been provided.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(
-        description="Update the asset register with new or disposed assets."
-    )
-    async def update_asset_register(asset_name: str, asset_details: str) -> str:
-        return (
-            f"##### Asset Register Updated\n"
-            f"**Asset:** {asset_name}\n"
-            f"**Details:** {asset_details}\n\n"
-            f"Asset register updated for {asset_name}: {asset_details}\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(
+    #     description="Update the asset register with new or disposed assets."
+    # )
+    # async def update_asset_register(asset_name: str, asset_details: str) -> str:
+    #     return (
+    #         f"##### Asset Register Updated\n"
+    #         f"**Asset:** {asset_name}\n"
+    #         f"**Details:** {asset_details}\n\n"
+    #         f"Asset register updated for {asset_name}: {asset_details}\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Manage leasing agreements for assets.")
-    async def manage_leasing_agreements(agreement_details: str) -> str:
-        return (
-            f"##### Leasing Agreement Managed\n"
-            f"**Agreement Details:** {agreement_details}\n\n"
-            f"Leasing agreement processed: {agreement_details}\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage leasing agreements for assets.")
+    # async def manage_leasing_agreements(agreement_details: str) -> str:
+    #     return (
+    #         f"##### Leasing Agreement Managed\n"
+    #         f"**Agreement Details:** {agreement_details}\n\n"
+    #         f"Leasing agreement processed: {agreement_details}\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Conduct market research for procurement purposes.")
-    async def conduct_market_research(category: str) -> str:
-        return (
-            f"##### Market Research Conducted\n"
-            f"**Category:** {category}\n\n"
-            f"Market research conducted for category: {category}\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Conduct market research for procurement purposes.")
+    # async def conduct_market_research(category: str) -> str:
+    #     return (
+    #         f"##### Market Research Conducted\n"
+    #         f"**Category:** {category}\n\n"
+    #         f"Market research conducted for category: {category}\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Schedule maintenance for equipment.")
-    async def schedule_maintenance(equipment_name: str, maintenance_date: str) -> str:
-        return (
-            f"##### Maintenance Scheduled\n"
-            f"**Equipment:** {equipment_name}\n"
-            f"**Date:** {maintenance_date}\n\n"
-            f"Scheduled maintenance for {equipment_name} on {maintenance_date}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Schedule maintenance for equipment.")
+    # async def schedule_maintenance(equipment_name: str, maintenance_date: str) -> str:
+    #     return (
+    #         f"##### Maintenance Scheduled\n"
+    #         f"**Equipment:** {equipment_name}\n"
+    #         f"**Date:** {maintenance_date}\n\n"
+    #         f"Scheduled maintenance for {equipment_name} on {maintenance_date}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Conduct an inventory audit.")
@@ -231,61 +231,61 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Approve a procurement budget.")
-    async def approve_budget(budget_id: str, amount: float) -> str:
-        return (
-            f"##### Budget Approved\n"
-            f"**Budget ID:** {budget_id}\n"
-            f"**Amount:** ${amount:.2f}\n\n"
-            f"Approved budget ID {budget_id} for amount ${amount:.2f}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Approve a procurement budget.")
+    # async def approve_budget(budget_id: str, amount: float) -> str:
+    #     return (
+    #         f"##### Budget Approved\n"
+    #         f"**Budget ID:** {budget_id}\n"
+    #         f"**Amount:** ${amount:.2f}\n\n"
+    #         f"Approved budget ID {budget_id} for amount ${amount:.2f}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Manage warranties for procured items.")
-    async def manage_warranty(item_name: str, warranty_period: str) -> str:
-        return (
-            f"##### Warranty Management\n"
-            f"**Item:** {item_name}\n"
-            f"**Warranty Period:** {warranty_period}\n\n"
-            f"Warranty for {item_name} managed for period {warranty_period}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage warranties for procured items.")
+    # async def manage_warranty(item_name: str, warranty_period: str) -> str:
+    #     return (
+    #         f"##### Warranty Management\n"
+    #         f"**Item:** {item_name}\n"
+    #         f"**Warranty Period:** {warranty_period}\n\n"
+    #         f"Warranty for {item_name} managed for period {warranty_period}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(
-        description="Handle customs clearance for international shipments."
-    )
-    async def handle_customs_clearance(shipment_id: str) -> str:
-        return (
-            f"##### Customs Clearance\n"
-            f"**Shipment ID:** {shipment_id}\n\n"
-            f"Customs clearance for shipment ID {shipment_id} handled.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(
+    #     description="Handle customs clearance for international shipments."
+    # )
+    # async def handle_customs_clearance(shipment_id: str) -> str:
+    #     return (
+    #         f"##### Customs Clearance\n"
+    #         f"**Shipment ID:** {shipment_id}\n\n"
+    #         f"Customs clearance for shipment ID {shipment_id} handled.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Negotiate a discount with a vendor.")
-    async def negotiate_discount(vendor_name: str, discount_percentage: float) -> str:
-        return (
-            f"##### Discount Negotiated\n"
-            f"**Vendor:** {vendor_name}\n"
-            f"**Discount:** {discount_percentage}%\n\n"
-            f"Negotiated a {discount_percentage}% discount with vendor {vendor_name}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Negotiate a discount with a vendor.")
+    # async def negotiate_discount(vendor_name: str, discount_percentage: float) -> str:
+    #     return (
+    #         f"##### Discount Negotiated\n"
+    #         f"**Vendor:** {vendor_name}\n"
+    #         f"**Discount:** {discount_percentage}%\n\n"
+    #         f"Negotiated a {discount_percentage}% discount with vendor {vendor_name}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Register a new vendor.")
-    async def register_new_vendor(vendor_name: str, vendor_details: str) -> str:
-        return (
-            f"##### New Vendor Registered\n"
-            f"**Vendor:** {vendor_name}\n"
-            f"**Details:** {vendor_details}\n\n"
-            f"New vendor {vendor_name} registered with details: {vendor_details}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Register a new vendor.")
+    # async def register_new_vendor(vendor_name: str, vendor_details: str) -> str:
+    #     return (
+    #         f"##### New Vendor Registered\n"
+    #         f"**Vendor:** {vendor_name}\n"
+    #         f"**Details:** {vendor_details}\n\n"
+    #         f"New vendor {vendor_name} registered with details: {vendor_details}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Decommission an asset.")
@@ -297,27 +297,27 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Schedule a training session for procurement staff.")
-    async def schedule_training(session_name: str, date: str) -> str:
-        return (
-            f"##### Training Session Scheduled\n"
-            f"**Session:** {session_name}\n"
-            f"**Date:** {date}\n\n"
-            f"Training session '{session_name}' scheduled on {date}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Schedule a training session for procurement staff.")
+    # async def schedule_training(session_name: str, date: str) -> str:
+    #     return (
+    #         f"##### Training Session Scheduled\n"
+    #         f"**Session:** {session_name}\n"
+    #         f"**Date:** {date}\n\n"
+    #         f"Training session '{session_name}' scheduled on {date}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Update the rating of a vendor.")
-    async def update_vendor_rating(vendor_name: str, rating: float) -> str:
-        return (
-            f"##### Vendor Rating Updated\n"
-            f"**Vendor:** {vendor_name}\n"
-            f"**Rating:** {rating}\n\n"
-            f"Vendor {vendor_name} rating updated to {rating}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Update the rating of a vendor.")
+    # async def update_vendor_rating(vendor_name: str, rating: float) -> str:
+    #     return (
+    #         f"##### Vendor Rating Updated\n"
+    #         f"**Vendor:** {vendor_name}\n"
+    #         f"**Rating:** {rating}\n\n"
+    #         f"Vendor {vendor_name} rating updated to {rating}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Handle the recall of a procured item.")
@@ -330,58 +330,58 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Request samples of an item.")
-    async def request_samples(item_name: str, quantity: int) -> str:
-        return (
-            f"##### Samples Requested\n"
-            f"**Item:** {item_name}\n"
-            f"**Quantity:** {quantity}\n\n"
-            f"Requested {quantity} samples of {item_name}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Request samples of an item.")
+    # async def request_samples(item_name: str, quantity: int) -> str:
+    #     return (
+    #         f"##### Samples Requested\n"
+    #         f"**Item:** {item_name}\n"
+    #         f"**Quantity:** {quantity}\n\n"
+    #         f"Requested {quantity} samples of {item_name}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Manage subscriptions to services.")
-    async def manage_subscription(service_name: str, action: str) -> str:
-        return (
-            f"##### Subscription Management\n"
-            f"**Service:** {service_name}\n"
-            f"**Action:** {action}\n\n"
-            f"Subscription to {service_name} has been {action}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage subscriptions to services.")
+    # async def manage_subscription(service_name: str, action: str) -> str:
+    #     return (
+    #         f"##### Subscription Management\n"
+    #         f"**Service:** {service_name}\n"
+    #         f"**Action:** {action}\n\n"
+    #         f"Subscription to {service_name} has been {action}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Verify the certification status of a supplier.")
-    async def verify_supplier_certification(supplier_name: str) -> str:
-        return (
-            f"##### Supplier Certification Verified\n"
-            f"**Supplier:** {supplier_name}\n\n"
-            f"Certification status of supplier {supplier_name} verified.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Verify the certification status of a supplier.")
+    # async def verify_supplier_certification(supplier_name: str) -> str:
+    #     return (
+    #         f"##### Supplier Certification Verified\n"
+    #         f"**Supplier:** {supplier_name}\n\n"
+    #         f"Certification status of supplier {supplier_name} verified.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Conduct an audit of a supplier.")
-    async def conduct_supplier_audit(supplier_name: str) -> str:
-        return (
-            f"##### Supplier Audit Conducted\n"
-            f"**Supplier:** {supplier_name}\n\n"
-            f"Audit of supplier {supplier_name} conducted.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Conduct an audit of a supplier.")
+    # async def conduct_supplier_audit(supplier_name: str) -> str:
+    #     return (
+    #         f"##### Supplier Audit Conducted\n"
+    #         f"**Supplier:** {supplier_name}\n\n"
+    #         f"Audit of supplier {supplier_name} conducted.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Manage import licenses for items.")
-    async def manage_import_licenses(item_name: str, license_details: str) -> str:
-        return (
-            f"##### Import License Management\n"
-            f"**Item:** {item_name}\n"
-            f"**License Details:** {license_details}\n\n"
-            f"Import license for {item_name} managed: {license_details}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage import licenses for items.")
+    # async def manage_import_licenses(item_name: str, license_details: str) -> str:
+    #     return (
+    #         f"##### Import License Management\n"
+    #         f"**Item:** {item_name}\n"
+    #         f"**License Details:** {license_details}\n\n"
+    #         f"Import license for {item_name} managed: {license_details}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Conduct a cost analysis for an item.")
@@ -405,15 +405,15 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Manage green procurement policy.")
-    async def manage_green_procurement_policy(policy_details: str) -> str:
-        return (
-            f"##### Green Procurement Policy Management\n"
-            f"**Details:** {policy_details}\n\n"
-            f"Green procurement policy managed: {policy_details}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage green procurement policy.")
+    # async def manage_green_procurement_policy(policy_details: str) -> str:
+    #     return (
+    #         f"##### Green Procurement Policy Management\n"
+    #         f"**Details:** {policy_details}\n\n"
+    #         f"Green procurement policy managed: {policy_details}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Update the supplier database with new information.")
@@ -426,49 +426,49 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Handle dispute resolution with a vendor.")
-    async def handle_dispute_resolution(vendor_name: str, issue: str) -> str:
-        return (
-            f"##### Dispute Resolution\n"
-            f"**Vendor:** {vendor_name}\n"
-            f"**Issue:** {issue}\n\n"
-            f"Dispute with vendor {vendor_name} over issue '{issue}' resolved.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Handle dispute resolution with a vendor.")
+    # async def handle_dispute_resolution(vendor_name: str, issue: str) -> str:
+    #     return (
+    #         f"##### Dispute Resolution\n"
+    #         f"**Vendor:** {vendor_name}\n"
+    #         f"**Issue:** {issue}\n\n"
+    #         f"Dispute with vendor {vendor_name} over issue '{issue}' resolved.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Assess compliance of an item with standards.")
-    async def assess_compliance(item_name: str, compliance_standards: str) -> str:
-        return (
-            f"##### Compliance Assessment\n"
-            f"**Item:** {item_name}\n"
-            f"**Standards:** {compliance_standards}\n\n"
-            f"Compliance of {item_name} with standards '{compliance_standards}' assessed.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Assess compliance of an item with standards.")
+    # async def assess_compliance(item_name: str, compliance_standards: str) -> str:
+    #     return (
+    #         f"##### Compliance Assessment\n"
+    #         f"**Item:** {item_name}\n"
+    #         f"**Standards:** {compliance_standards}\n\n"
+    #         f"Compliance of {item_name} with standards '{compliance_standards}' assessed.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Manage reverse logistics for returning items.")
-    async def manage_reverse_logistics(item_name: str, quantity: int) -> str:
-        return (
-            f"##### Reverse Logistics Management\n"
-            f"**Item:** {item_name}\n"
-            f"**Quantity:** {quantity}\n\n"
-            f"Reverse logistics managed for {quantity} units of {item_name}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage reverse logistics for returning items.")
+    # async def manage_reverse_logistics(item_name: str, quantity: int) -> str:
+    #     return (
+    #         f"##### Reverse Logistics Management\n"
+    #         f"**Item:** {item_name}\n"
+    #         f"**Quantity:** {quantity}\n\n"
+    #         f"Reverse logistics managed for {quantity} units of {item_name}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Verify delivery status of an item.")
-    async def verify_delivery(item_name: str, delivery_status: str) -> str:
-        return (
-            f"##### Delivery Status Verification\n"
-            f"**Item:** {item_name}\n"
-            f"**Status:** {delivery_status}\n\n"
-            f"Delivery status of {item_name} verified as {delivery_status}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Verify delivery status of an item.")
+    # async def verify_delivery(item_name: str, delivery_status: str) -> str:
+    #     return (
+    #         f"##### Delivery Status Verification\n"
+    #         f"**Item:** {item_name}\n"
+    #         f"**Status:** {delivery_status}\n\n"
+    #         f"Delivery status of {item_name} verified as {delivery_status}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="assess procurement risk assessment.")
@@ -480,37 +480,37 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Manage supplier contract actions.")
-    async def manage_supplier_contract(supplier_name: str, contract_action: str) -> str:
-        return (
-            f"##### Supplier Contract Management\n"
-            f"**Supplier:** {supplier_name}\n"
-            f"**Action:** {contract_action}\n\n"
-            f"Supplier contract with {supplier_name} has been {contract_action}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Manage supplier contract actions.")
+    # async def manage_supplier_contract(supplier_name: str, contract_action: str) -> str:
+    #     return (
+    #         f"##### Supplier Contract Management\n"
+    #         f"**Supplier:** {supplier_name}\n"
+    #         f"**Action:** {contract_action}\n\n"
+    #         f"Supplier contract with {supplier_name} has been {contract_action}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Allocate budget to a department.")
-    async def allocate_budget(department_name: str, budget_amount: float) -> str:
-        return (
-            f"##### Budget Allocation\n"
-            f"**Department:** {department_name}\n"
-            f"**Amount:** ${budget_amount:.2f}\n\n"
-            f"Allocated budget of ${budget_amount:.2f} to {department_name}.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Allocate budget to a department.")
+    # async def allocate_budget(department_name: str, budget_amount: float) -> str:
+    #     return (
+    #         f"##### Budget Allocation\n"
+    #         f"**Department:** {department_name}\n"
+    #         f"**Amount:** ${budget_amount:.2f}\n\n"
+    #         f"Allocated budget of ${budget_amount:.2f} to {department_name}.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
-    @staticmethod
-    @kernel_function(description="Track procurement metrics.")
-    async def track_procurement_metrics(metric_name: str) -> str:
-        return (
-            f"##### Procurement Metrics Tracking\n"
-            f"**Metric:** {metric_name}\n\n"
-            f"Procurement metric '{metric_name}' tracked.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Track procurement metrics.")
+    # async def track_procurement_metrics(metric_name: str) -> str:
+    #     return (
+    #         f"##### Procurement Metrics Tracking\n"
+    #         f"**Metric:** {metric_name}\n\n"
+    #         f"Procurement metric '{metric_name}' tracked.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(description="Manage inventory levels for an item.")
@@ -523,15 +523,15 @@ class ProcurementTools:
             f"{ProcurementTools.formatting_instructions}"
         )
 
-    @staticmethod
-    @kernel_function(description="Conduct a survey of a supplier.")
-    async def conduct_supplier_survey(supplier_name: str) -> str:
-        return (
-            f"##### Supplier Survey Conducted\n"
-            f"**Supplier:** {supplier_name}\n\n"
-            f"Survey of supplier {supplier_name} conducted.\n"
-            f"{ProcurementTools.formatting_instructions}"
-        )
+    # @staticmethod
+    # @kernel_function(description="Conduct a survey of a supplier.")
+    # async def conduct_supplier_survey(supplier_name: str) -> str:
+    #     return (
+    #         f"##### Supplier Survey Conducted\n"
+    #         f"**Supplier:** {supplier_name}\n\n"
+    #         f"Survey of supplier {supplier_name} conducted.\n"
+    #         f"{ProcurementTools.formatting_instructions}"
+    #     )
 
     @staticmethod
     @kernel_function(
@@ -636,7 +636,7 @@ class ProcurementTools:
                 tools_list.append(tool_entry)
 
         # Return the JSON string representation
-        return json.dumps(tools_list, ensure_ascii=False, indent=2)
+        return json.dumps(tools_list, ensure_ascii=False)
 
     # This function does NOT have the kernel_function annotation
     # because it's meant for introspection rather than being exposed as a tool

--- a/src/backend/kernel_tools/product_tools.py
+++ b/src/backend/kernel_tools/product_tools.py
@@ -2,7 +2,6 @@
 
 import inspect
 import time
-from datetime import datetime
 from typing import Annotated, Callable, List
 
 from semantic_kernel.functions import kernel_function
@@ -75,17 +74,17 @@ class ProductTools:
         """
         return f"Here is information to relay back to the user. Repeat back all the relevant sections that the user asked for: {product_info}."
 
-    @staticmethod
-    @kernel_function(
-        description="Retrieve the customer's recurring billing date information."
-    )
-    async def get_billing_date() -> str:
-        """Get information about the recurring billing date."""
-        now = datetime.now()
-        start_of_month = datetime(now.year, now.month, 1)
-        start_of_month_string = start_of_month.strftime("%Y-%m-%d")
-        formatted_date = format_date_for_user(start_of_month_string)
-        return f"## Billing Date\nYour most recent billing date was **{formatted_date}**."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Retrieve the customer's recurring billing date information."
+    # )
+    # async def get_billing_date() -> str:
+    #     """Get information about the recurring billing date."""
+    #     now = datetime.now()
+    #     start_of_month = datetime(now.year, now.month, 1)
+    #     start_of_month_string = start_of_month.strftime("%Y-%m-%d")
+    #     formatted_date = format_date_for_user(start_of_month_string)
+    #     return f"## Billing Date\nYour most recent billing date was **{formatted_date}**."
 
     @staticmethod
     @kernel_function(
@@ -120,15 +119,15 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Update the price of a specified product in the system."
-    )
-    async def update_product_price(product_name: str, price: float) -> str:
-        """Update the price of a specific product."""
-        message = f"## Price Update\nPrice for **'{product_name}'** updated to **${price:.2f}**."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Update the price of a specified product in the system."
+    # )
+    # async def update_product_price(product_name: str, price: float) -> str:
+    #     """Update the price of a specific product."""
+    #     message = f"## Price Update\nPrice for **'{product_name}'** updated to **${price:.2f}**."
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(description="Schedule a product launch event on a specific date.")
@@ -139,23 +138,23 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Analyze sales data for a product over a specified time period."
-    )
-    async def analyze_sales_data(product_name: str, time_period: str) -> str:
-        """Analyze sales data for a product over a given time period."""
-        analysis = f"## Sales Data Analysis\nSales data for **'{product_name}'** over **{time_period}** analyzed."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Analyze sales data for a product over a specified time period."
+    # )
+    # async def analyze_sales_data(product_name: str, time_period: str) -> str:
+    #     """Analyze sales data for a product over a given time period."""
+    #     analysis = f"## Sales Data Analysis\nSales data for **'{product_name}'** over **{time_period}** analyzed."
 
-        return analysis
+    #     return analysis
 
-    @staticmethod
-    @kernel_function(description="Retrieve customer feedback for a specified product.")
-    async def get_customer_feedback(product_name: str) -> str:
-        """Retrieve customer feedback for a specific product."""
-        feedback = f"## Customer Feedback\nCustomer feedback for **'{product_name}'** retrieved."
+    # @staticmethod
+    # @kernel_function(description="Retrieve customer feedback for a specified product.")
+    # async def get_customer_feedback(product_name: str) -> str:
+    #     """Retrieve customer feedback for a specific product."""
+    #     feedback = f"## Customer Feedback\nCustomer feedback for **'{product_name}'** retrieved."
 
-        return feedback
+    #     return feedback
 
     @staticmethod
     @kernel_function(
@@ -183,17 +182,17 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Review and assess the quality of a specified product."
-    )
-    async def review_product_quality(product_name: str) -> str:
-        """Review the quality of a specific product."""
-        review = (
-            f"## Quality Review\nQuality review for **'{product_name}'** completed."
-        )
+    # @staticmethod
+    # @kernel_function(
+    #     description="Review and assess the quality of a specified product."
+    # )
+    # async def review_product_quality(product_name: str) -> str:
+    #     """Review the quality of a specific product."""
+    #     review = (
+    #         f"## Quality Review\nQuality review for **'{product_name}'** completed."
+    #     )
 
-        return review
+    #     return review
 
     @staticmethod
     @kernel_function(
@@ -205,17 +204,17 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Provide product recommendations based on customer preferences."
-    )
-    async def provide_product_recommendations(
-        customer_preferences: Annotated[str, "Customer preferences or requirements"],
-    ) -> str:
-        """Provide product recommendations based on customer preferences."""
-        recommendations = f"## Product Recommendations\nProduct recommendations based on preferences **'{customer_preferences}'** provided."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Provide product recommendations based on customer preferences."
+    # )
+    # async def provide_product_recommendations(
+    #     customer_preferences: Annotated[str, "Customer preferences or requirements"],
+    # ) -> str:
+    #     """Provide product recommendations based on customer preferences."""
+    #     recommendations = f"## Product Recommendations\nProduct recommendations based on preferences **'{customer_preferences}'** provided."
 
-        return recommendations
+    #     return recommendations
 
     @staticmethod
     @kernel_function(description="Generate a detailed report for a specified product.")
@@ -225,35 +224,35 @@ class ProductTools:
 
         return report
 
-    @staticmethod
-    @kernel_function(
-        description="Manage supply chain activities for a specified product with a particular supplier."
-    )
-    async def manage_supply_chain(product_name: str, supplier_name: str) -> str:
-        """Manage supply chain activities for a specific product."""
-        message = f"## Supply Chain Management\nSupply chain for **'{product_name}'** managed with supplier **'{supplier_name}'**."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Manage supply chain activities for a specified product with a particular supplier."
+    # )
+    # async def manage_supply_chain(product_name: str, supplier_name: str) -> str:
+    #     """Manage supply chain activities for a specific product."""
+    #     message = f"## Supply Chain Management\nSupply chain for **'{product_name}'** managed with supplier **'{supplier_name}'**."
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Track the shipment status of a specified product using a tracking number."
-    )
-    async def track_product_shipment(product_name: str, tracking_number: str) -> str:
-        """Track the shipment of a specific product."""
-        status = f"## Shipment Tracking\nShipment for **'{product_name}'** with tracking number **'{tracking_number}'** tracked."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Track the shipment status of a specified product using a tracking number."
+    # )
+    # async def track_product_shipment(product_name: str, tracking_number: str) -> str:
+    #     """Track the shipment of a specific product."""
+    #     status = f"## Shipment Tracking\nShipment for **'{product_name}'** with tracking number **'{tracking_number}'** tracked."
 
-        return status
+    #     return status
 
-    @staticmethod
-    @kernel_function(
-        description="Set the reorder threshold level for a specified product."
-    )
-    async def set_reorder_level(product_name: str, reorder_level: int) -> str:
-        """Set the reorder level for a specific product."""
-        message = f"## Reorder Level Set\nReorder level for **'{product_name}'** set to **{reorder_level}** units."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Set the reorder threshold level for a specified product."
+    # )
+    # async def set_reorder_level(product_name: str, reorder_level: int) -> str:
+    #     """Set the reorder level for a specific product."""
+    #     message = f"## Reorder Level Set\nReorder level for **'{product_name}'** set to **{reorder_level}** units."
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(
@@ -288,67 +287,67 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Update the description information for a specified product."
-    )
-    async def update_product_description(product_name: str, description: str) -> str:
-        """Update the description of a specific product."""
-        message = f"## Product Description Updated\nDescription for **'{product_name}'** updated to:\n\n{description}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Update the description information for a specified product."
+    # )
+    # async def update_product_description(product_name: str, description: str) -> str:
+    #     """Update the description of a specific product."""
+    #     message = f"## Product Description Updated\nDescription for **'{product_name}'** updated to:\n\n{description}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(description="Set a percentage discount for a specified product.")
-    async def set_product_discount(
-        product_name: str, discount_percentage: float
-    ) -> str:
-        """Set a discount for a specific product."""
-        message = f"## Discount Set\nDiscount for **'{product_name}'** set to **{discount_percentage}%**."
+    # @staticmethod
+    # @kernel_function(description="Set a percentage discount for a specified product.")
+    # async def set_product_discount(
+    #     product_name: str, discount_percentage: float
+    # ) -> str:
+    #     """Set a discount for a specific product."""
+    #     message = f"## Discount Set\nDiscount for **'{product_name}'** set to **{discount_percentage}%**."
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Process and manage product returns with detailed reason tracking."
-    )
-    async def manage_product_returns(product_name: str, return_reason: str) -> str:
-        """Manage returns for a specific product."""
-        message = f"## Product Return Managed\nReturn for **'{product_name}'** managed due to:\n\n{return_reason}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Process and manage product returns with detailed reason tracking."
+    # )
+    # async def manage_product_returns(product_name: str, return_reason: str) -> str:
+    #     """Manage returns for a specific product."""
+    #     message = f"## Product Return Managed\nReturn for **'{product_name}'** managed due to:\n\n{return_reason}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(description="Conduct a customer survey about a specified product.")
-    async def conduct_product_survey(product_name: str, survey_details: str) -> str:
-        """Conduct a survey for a specific product."""
-        message = f"## Product Survey Conducted\nSurvey for **'{product_name}'** conducted with details:\n\n{survey_details}"
+    # @staticmethod
+    # @kernel_function(description="Conduct a customer survey about a specified product.")
+    # async def conduct_product_survey(product_name: str, survey_details: str) -> str:
+    #     """Conduct a survey for a specific product."""
+    #     message = f"## Product Survey Conducted\nSurvey for **'{product_name}'** conducted with details:\n\n{survey_details}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Handle and process customer complaints about a specified product."
-    )
-    async def handle_product_complaints(
-        product_name: str, complaint_details: str
-    ) -> str:
-        """Handle complaints for a specific product."""
-        message = f"## Product Complaint Handled\nComplaint for **'{product_name}'** handled with details:\n\n{complaint_details}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Handle and process customer complaints about a specified product."
+    # )
+    # async def handle_product_complaints(
+    #     product_name: str, complaint_details: str
+    # ) -> str:
+    #     """Handle complaints for a specific product."""
+    #     message = f"## Product Complaint Handled\nComplaint for **'{product_name}'** handled with details:\n\n{complaint_details}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Update the technical specifications for a specified product."
-    )
-    async def update_product_specifications(
-        product_name: str, specifications: str
-    ) -> str:
-        """Update the specifications for a specific product."""
-        message = f"## Product Specifications Updated\nSpecifications for **'{product_name}'** updated to:\n\n{specifications}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Update the technical specifications for a specified product."
+    # )
+    # async def update_product_specifications(
+    #     product_name: str, specifications: str
+    # ) -> str:
+    #     """Update the specifications for a specific product."""
+    #     message = f"## Product Specifications Updated\nSpecifications for **'{product_name}'** updated to:\n\n{specifications}"
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(
@@ -372,14 +371,14 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(description="Set the availability status of a specified product.")
-    async def set_product_availability(product_name: str, availability: bool) -> str:
-        """Set the availability status of a specific product."""
-        status = "available" if availability else "unavailable"
-        message = f"## Product Availability Set\nProduct **'{product_name}'** is now **{status}**."
+    # @staticmethod
+    # @kernel_function(description="Set the availability status of a specified product.")
+    # async def set_product_availability(product_name: str, availability: bool) -> str:
+    #     """Set the availability status of a specific product."""
+    #     status = "available" if availability else "unavailable"
+    #     message = f"## Product Availability Set\nProduct **'{product_name}'** is now **{status}**."
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(
@@ -393,18 +392,18 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Calculate the profit margin for a specified product using cost and selling prices."
-    )
-    async def calculate_product_margin(
-        product_name: str, cost_price: float, selling_price: float
-    ) -> str:
-        """Calculate the profit margin for a specific product."""
-        margin = ((selling_price - cost_price) / selling_price) * 100
-        message = f"## Profit Margin Calculated\nProfit margin for **'{product_name}'** calculated at **{margin:.2f}%**."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Calculate the profit margin for a specified product using cost and selling prices."
+    # )
+    # async def calculate_product_margin(
+    #     product_name: str, cost_price: float, selling_price: float
+    # ) -> str:
+    #     """Calculate the profit margin for a specific product."""
+    #     margin = ((selling_price - cost_price) / selling_price) * 100
+    #     message = f"## Profit Margin Calculated\nProfit margin for **'{product_name}'** calculated at **{margin:.2f}%**."
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(
@@ -416,38 +415,38 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Create and manage product bundles with multiple products."
-    )
-    async def manage_product_bundles(bundle_name: str, product_list: List[str]) -> str:
-        """Manage product bundles."""
-        products = ", ".join(product_list)
-        message = f"## Product Bundle Managed\nProduct bundle **'{bundle_name}'** managed with products:\n\n{products}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Create and manage product bundles with multiple products."
+    # )
+    # async def manage_product_bundles(bundle_name: str, product_list: List[str]) -> str:
+    #     """Manage product bundles."""
+    #     products = ", ".join(product_list)
+    #     message = f"## Product Bundle Managed\nProduct bundle **'{bundle_name}'** managed with products:\n\n{products}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Optimize the product page for better user experience and performance."
-    )
-    async def optimize_product_page(
-        product_name: str, optimization_details: str
-    ) -> str:
-        """Optimize the product page for better performance."""
-        message = f"## Product Page Optimized\nProduct page for **'{product_name}'** optimized with details:\n\n{optimization_details}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Optimize the product page for better user experience and performance."
+    # )
+    # async def optimize_product_page(
+    #     product_name: str, optimization_details: str
+    # ) -> str:
+    #     """Optimize the product page for better performance."""
+    #     message = f"## Product Page Optimized\nProduct page for **'{product_name}'** optimized with details:\n\n{optimization_details}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Monitor and track performance metrics for a specified product."
-    )
-    async def monitor_product_performance(product_name: str) -> str:
-        """Monitor the performance of a specific product."""
-        message = f"## Product Performance Monitored\nPerformance for **'{product_name}'** monitored."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Monitor and track performance metrics for a specified product."
+    # )
+    # async def monitor_product_performance(product_name: str) -> str:
+    #     """Monitor the performance of a specific product."""
+    #     message = f"## Product Performance Monitored\nPerformance for **'{product_name}'** monitored."
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(
@@ -469,47 +468,47 @@ class ProductTools:
 
         return message
 
-    @staticmethod
-    @kernel_function(
-        description="Update the labeling information for a specified product."
-    )
-    async def update_product_labels(product_name: str, label_details: str) -> str:
-        """Update labels for a specific product."""
-        message = f"## Product Labels Updated\nLabels for **'{product_name}'** updated with details:\n\n{label_details}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Update the labeling information for a specified product."
+    # )
+    # async def update_product_labels(product_name: str, label_details: str) -> str:
+    #     """Update labels for a specific product."""
+    #     message = f"## Product Labels Updated\nLabels for **'{product_name}'** updated with details:\n\n{label_details}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Manage warranty terms and conditions for a specified product."
-    )
-    async def manage_product_warranty(product_name: str, warranty_details: str) -> str:
-        """Manage the warranty for a specific product."""
-        message = f"## Product Warranty Managed\nWarranty for **'{product_name}'** managed with details:\n\n{warranty_details}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Manage warranty terms and conditions for a specified product."
+    # )
+    # async def manage_product_warranty(product_name: str, warranty_details: str) -> str:
+    #     """Manage the warranty for a specific product."""
+    #     message = f"## Product Warranty Managed\nWarranty for **'{product_name}'** managed with details:\n\n{warranty_details}"
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Forecast future demand for a specified product over a time period."
-    )
-    async def forecast_product_demand(product_name: str, forecast_period: str) -> str:
-        """Forecast demand for a specific product."""
-        message = f"## Demand Forecast\nDemand for **'{product_name}'** forecasted for **{forecast_period}**."
+    # @staticmethod
+    # @kernel_function(
+    #     description="Forecast future demand for a specified product over a time period."
+    # )
+    # async def forecast_product_demand(product_name: str, forecast_period: str) -> str:
+    #     """Forecast demand for a specific product."""
+    #     message = f"## Demand Forecast\nDemand for **'{product_name}'** forecasted for **{forecast_period}**."
 
-        return message
+    #     return message
 
-    @staticmethod
-    @kernel_function(
-        description="Handle licensing agreements and requirements for a specified product."
-    )
-    async def handle_product_licensing(
-        product_name: str, licensing_details: str
-    ) -> str:
-        """Handle licensing for a specific product."""
-        message = f"## Product Licensing Handled\nLicensing for **'{product_name}'** handled with details:\n\n{licensing_details}"
+    # @staticmethod
+    # @kernel_function(
+    #     description="Handle licensing agreements and requirements for a specified product."
+    # )
+    # async def handle_product_licensing(
+    #     product_name: str, licensing_details: str
+    # ) -> str:
+    #     """Handle licensing for a specific product."""
+    #     message = f"## Product Licensing Handled\nLicensing for **'{product_name}'** handled with details:\n\n{licensing_details}"
 
-        return message
+    #     return message
 
     @staticmethod
     @kernel_function(
@@ -693,7 +692,7 @@ class ProductTools:
                 tools_list.append(tool_entry)
 
         # Return the JSON string representation
-        return json.dumps(tools_list, ensure_ascii=False, indent=2)
+        return json.dumps(tools_list, ensure_ascii=False)
 
     # This function does NOT have the kernel_function annotation
     # because it's meant for introspection rather than being exposed as a tool

--- a/src/backend/kernel_tools/tech_support_tools.py
+++ b/src/backend/kernel_tools/tech_support_tools.py
@@ -378,7 +378,7 @@ class TechSupportTools:
                 tools_list.append(tool_entry)
 
         # Return the JSON string representation
-        return json.dumps(tools_list, ensure_ascii=False, indent=2)
+        return json.dumps(tools_list, ensure_ascii=False)
 
     # This function does NOT have the kernel_function annotation
     # because it's meant for introspection rather than being exposed as a tool

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.11"
 dependencies = [
     "azure-ai-evaluation>=1.5.0",
     "azure-ai-inference>=1.0.0b9",
-    "azure-ai-projects>=1.0.0b9",
-    "azure-ai-agents>=1.2.0b1",
+    "azure-ai-projects==1.0.0",
+    "azure-ai-agents==1.2.0b2",
     "azure-cosmos>=4.9.0",
     "azure-identity>=1.21.0",
     "azure-monitor-events-extension>=0.1.0",
@@ -27,6 +27,6 @@ dependencies = [
     "pytest-cov==5.0.0",
     "python-dotenv>=1.1.0",
     "python-multipart>=0.0.20",
-    "semantic-kernel>=1.32.2",
+    "semantic-kernel==1.35.3",
     "uvicorn>=0.34.2",
 ]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -226,16 +226,16 @@ wheels = [
 
 [[package]]
 name = "azure-ai-agents"
-version = "1.2.0b1"
+version = "1.2.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/70/0aa275a7eecead1691bd86474514bc28787f815c37d1d79ac78be03a7612/azure_ai_agents-1.2.0b1.tar.gz", hash = "sha256:914e08e553ea4379d41ad60dbc8ea5468311d97f0ae1a362686229b8565ab8dd", size = 339933, upload-time = "2025-08-05T22:21:07.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/07/97eb5d1355abbd572c187789ae6c17d36dfcb3a9a1fae002e660d2663bf6/azure_ai_agents-1.2.0b2.tar.gz", hash = "sha256:4d9d220c12e2b7741f67bd7ef35e4faa60de7da32c0ab2526fa0ce1b978c2537", size = 353885, upload-time = "2025-08-12T21:35:46.264Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/c2/4824f3cd3980f976c4dace59cb25ab1891b22626be5c80c4a96f0b9c0ba5/azure_ai_agents-1.2.0b1-py3-none-any.whl", hash = "sha256:c6862f2e6655072ee3f1f1489be2dc2bf6c0ad636ec4e7f33a5fca9cb5c8eadb", size = 202032, upload-time = "2025-08-05T22:21:08.668Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9d/59688d265026e84dfff39b26d24cdbce0b2a2466a5bed06e0874a2a58e90/azure_ai_agents-1.2.0b2-py3-none-any.whl", hash = "sha256:f82117029fcc1dbed24d6b6c94d7e60e6b75276c333329fcfd9238853c82020b", size = 204422, upload-time = "2025-08-12T21:35:48.057Z" },
 ]
 
 [[package]]
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "azure-ai-projects"
-version = "1.1.0b2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-ai-agents" },
@@ -286,9 +286,9 @@ dependencies = [
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/17/33664227381ff59690e16a8d3261c9edeb80d88acdb24b717733d63529bb/azure_ai_projects-1.1.0b2.tar.gz", hash = "sha256:79432e2de8b27f01aaad6d3f12e1549396f1c2a022665a859c45b179bf6ff228", size = 144848, upload-time = "2025-08-05T22:18:45.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/95/9c04cb5f658c7f856026aa18432e0f0fa254ead2983a3574a0f5558a7234/azure_ai_projects-1.0.0.tar.gz", hash = "sha256:b5f03024ccf0fd543fbe0f5abcc74e45b15eccc1c71ab87fc71c63061d9fd63c", size = 130798, upload-time = "2025-07-31T02:09:27.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/2b/98f928ea41c03c78c02e1a72fc5e9c900d2e6e472cb51f9272cb0d4ba3bf/azure_ai_projects-1.1.0b2-py3-none-any.whl", hash = "sha256:3a4ecc6de6ab27a75b4c8228cd8162c9853fd1432e77746792b0ee2088c775db", size = 125301, upload-time = "2025-08-05T22:18:46.577Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/db/7149cdf71e12d9737f186656176efc94943ead4f205671768c1549593efe/azure_ai_projects-1.0.0-py3-none-any.whl", hash = "sha256:81369ed7a2f84a65864f57d3fa153e16c30f411a1504d334e184fb070165a3fa", size = 115188, upload-time = "2025-07-31T02:09:29.362Z" },
 ]
 
 [[package]]
@@ -473,10 +473,10 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "azure-ai-agents", specifier = ">=1.2.0b1" },
+    { name = "azure-ai-agents", specifier = "==1.2.0b2" },
     { name = "azure-ai-evaluation", specifier = ">=1.5.0" },
     { name = "azure-ai-inference", specifier = ">=1.0.0b9" },
-    { name = "azure-ai-projects", specifier = ">=1.0.0b9" },
+    { name = "azure-ai-projects", specifier = "==1.0.0" },
     { name = "azure-cosmos", specifier = ">=4.9.0" },
     { name = "azure-identity", specifier = ">=1.21.0" },
     { name = "azure-monitor-events-extension", specifier = ">=0.1.0" },
@@ -495,7 +495,7 @@ requires-dist = [
     { name = "pytest-cov", specifier = "==5.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
-    { name = "semantic-kernel", specifier = ">=1.32.2" },
+    { name = "semantic-kernel", specifier = "==1.35.3" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]
 
@@ -1652,7 +1652,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.76.2"
+version = "1.100.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1664,9 +1664,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/48/e767710b07acc1fca1f6b8cacd743102c71b8fdeca603876de0749ec00f1/openai-1.76.2.tar.gz", hash = "sha256:f430c8b848775907405c6eff54621254c96f6444c593c097e0cc3a9f8fdda96f", size = 434922, upload-time = "2025-04-29T20:02:56.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/36/e2e24d419438a5e66aa6445ec663194395226293d214bfe615df562b2253/openai-1.100.2.tar.gz", hash = "sha256:787b4c3c8a65895182c58c424f790c25c790cc9a0330e34f73d55b6ee5a00e32", size = 507954, upload-time = "2025-08-19T15:32:47.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/5f/aecb820917e93ca9fcac408e998dc22ee0561c308ed58dc8f328e3f7ef14/openai-1.76.2-py3-none-any.whl", hash = "sha256:9c1d9ad59e6e3bea7205eedc9ca66eeebae18d47b527e505a2b0d2fb1538e26e", size = 661253, upload-time = "2025-04-29T20:02:54.362Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/9ab1599c7942b3d04784ac5473905dc543aeb30a1acce3591d0b425682db/openai-1.100.2-py3-none-any.whl", hash = "sha256:54d3457b2c8d7303a1bc002a058de46bdd8f37a8117751c7cf4ed4438051f151", size = 787755, upload-time = "2025-08-19T15:32:46.252Z" },
 ]
 
 [[package]]
@@ -2957,7 +2957,7 @@ wheels = [
 
 [[package]]
 name = "semantic-kernel"
-version = "1.35.0"
+version = "1.35.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2983,9 +2983,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/5c/4d761ff412c211260415f0e6683d22139b4ab990d9010c9962d1ec35d1b8/semantic_kernel-1.35.0.tar.gz", hash = "sha256:7fe49faaf7086263d3ac4cb42ec5d0b2344dcc21f0759bd6b79a92a7b4f8533f", size = 572339, upload-time = "2025-07-16T00:33:47.948Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c7/6319e51fea5d51fce21df597f58b0634a7505128e05aa9720ac7c996d215/semantic_kernel-1.35.3.tar.gz", hash = "sha256:fd6ae00ee50ac53ac830dceddafc652a4f178990c809f71b516ffa2d414886fe", size = 574198, upload-time = "2025-08-14T00:35:00.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/14/b0ddf679dae28393cf068401e8f953602adf78d1fe17504479ddf9f7afdf/semantic_kernel-1.35.0-py3-none-any.whl", hash = "sha256:ce2b9c313d53841448059833e885f082d136c54a113e687359b14c5e358c0e66", size = 875792, upload-time = "2025-07-16T00:33:45.891Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/44314fcd4816367084e6df7698508b397d683f63b0d7b5acd86003b7b377/semantic_kernel-1.35.3-py3-none-any.whl", hash = "sha256:11c97405530c1c266df8589f3c0775e7fab7b92b17df19e0dfaee44f47cac5fa", size = 882352, upload-time = "2025-08-14T00:34:57.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request primarily removes or comments out a large number of HR and marketing tool functions from the backend, likely to reduce available functionality or for refactoring purposes. Additionally, it standardizes the JSON output format in tool documentation by removing indentation. There are also minor changes to how tool lists are handled in the planner agent and template.

The most important changes are:

### Removal/commenting out of tool functions

* Most HR-related functions in `hr_tools.py` have been commented out, including processing leave requests, updating policies, conducting exit interviews, scheduling reviews, approving expenses, managing transfers, tracking attendance, and more. This significantly reduces the available HR automation capabilities. [[1]](diffhunk://#diff-edf02d1383c245556928615cdbc13259357cbfef14ab36647cca58bf985b1769L122-R160) [[2]](diffhunk://#diff-edf02d1383c245556928615cdbc13259357cbfef14ab36647cca58bf985b1769L172-R204) [[3]](diffhunk://#diff-edf02d1383c245556928615cdbc13259357cbfef14ab36647cca58bf985b1769L255-R287) [[4]](diffhunk://#diff-edf02d1383c245556928615cdbc13259357cbfef14ab36647cca58bf985b1769L302-R368)
* Several marketing tool functions in `marketing_tools.py` have been commented out, such as conducting customer surveys, scheduling marketing events, tracking campaign performance, developing brand strategies, creating content calendars, and updating website content. [[1]](diffhunk://#diff-4206d878e8ad909ab64d68482833c344190ebd5266de70b366fc4b689732e0ceL40-R57) [[2]](diffhunk://#diff-4206d878e8ad909ab64d68482833c344190ebd5266de70b366fc4b689732e0ceL71-R94)

### JSON output formatting

* The JSON output for tool documentation in both `generic_tools.py` and `hr_tools.py` is now generated without indentation, resulting in a more compact format. [[1]](diffhunk://#diff-3e5f968db3e05f985ddbcb979d249e54179a30acbd1b84d5ec12ad15ed7b0773L133-R133) [[2]](diffhunk://#diff-edf02d1383c245556928615cdbc13259357cbfef14ab36647cca58bf985b1769L488-R488)

### Planner agent changes

* In `planner_agent.py`, the `tools_list` is now passed directly (as a list) instead of being stringified, which may affect template rendering or downstream processing.
* A line in the planner agent's template that instructed the agent to ask the user for additional information in the first step has been removed, potentially altering the initial planning behavior.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->