### PR TITLE
fix: reverted the original prompt of planner agent

### DIFF
--- a/src/backend/kernel_agents/planner_agent.py
+++ b/src/backend/kernel_agents/planner_agent.py
@@ -568,7 +568,8 @@ class PlannerAgent(BaseAgent):
             These agents have access to the following functions:
             {{$tools_str}}
 
-
+            The first step of your plan should be to ask the user for any additional information required to progress the rest of steps planned.
+            
             Only use the functions provided as part of your plan. If the task is not possible with the agents and tools provided, create a step with the agent of type Human and mark the overall status as completed.
 
             Do not add superfluous steps - only take the most direct path to the solution, with the minimum number of steps. Only do the minimum necessary to complete the goal.

--- a/src/backend/kernel_agents/planner_agent.py
+++ b/src/backend/kernel_agents/planner_agent.py
@@ -569,7 +569,7 @@ class PlannerAgent(BaseAgent):
             {{$tools_str}}
 
             The first step of your plan should be to ask the user for any additional information required to progress the rest of steps planned.
-            
+
             Only use the functions provided as part of your plan. If the task is not possible with the agents and tools provided, create a step with the agent of type Human and mark the overall status as completed.
 
             Do not add superfluous steps - only take the most direct path to the solution, with the minimum number of steps. Only do the minimum necessary to complete the goal.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request makes a small update to the planner agent's template prompt. The main change is to instruct the agent to first ask the user for any additional information needed before proceeding with the rest of the planned steps. 

([src/backend/kernel_agents/planner_agent.py](diffhunk://#diff-26fed13874b0912fe85301592ef349a3ac2979e6791f384ff7aaacf87ab8b5d1R571))

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->