### PR TITLE
docs: clarify navigation by adding step to enter 'infra' directory before 'scripts'

### DIFF
--- a/docs/quota_check.md
+++ b/docs/quota_check.md
@@ -79,6 +79,7 @@ The final table lists regions with available quota. You can select any of these 
    ![git_bash](images/git_bash.png)
 3. Navigate to the `scripts` folder where the script files are located and make the script as executable:
    ```sh
+    cd infra
     cd scripts
     chmod +x quota_check_params.sh
     ```


### PR DESCRIPTION
Added a step to navigate to the 'infra' directory before accessing the 'scripts' folder.

## Purpose
This pull request makes a minor update to the documentation, clarifying the correct navigation steps for running quota check scripts.

* In `docs/quota_check.md`, added a step to change into the `infra` directory before entering the `scripts` folder, improving instructions for locating and executing the script.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->