### PR TITLE
chore: Add deployer name in Createdby tag

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -165,6 +165,25 @@ var replicaLocation = replicaRegionPairs[location]
 // Resources      //
 // ============== //
 
+var deployerInfo = deployer()
+var allTags = union(
+  {
+    'azd-env-name': solutionName
+  },
+  tags
+)
+resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
+  name: 'default'
+  properties: {
+    tags: {
+      ...allTags
+      TemplateName: 'MACAE'
+      CreatedBy: split(deployerInfo.userPrincipalName, '@')[0] 
+    }
+  }
+}
+
+
 #disable-next-line no-deployments-resources
 resource avmTelemetry 'Microsoft.Resources/deployments@2024-03-01' = if (enableTelemetry) {
   name: '46d3xbcp.ptn.sa-multiagentcustauteng.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'


### PR DESCRIPTION
## Purpose

This pull request introduces tagging enhancements to the infrastructure deployment process in `infra/main.bicep`. The main change is the addition of a resource to apply standardized and informative tags to the resource group, improving resource management and traceability.

Tagging improvements:

* Added a new `resourceGroupTags` resource that applies a set of tags to the resource group, including environment name (`azd-env-name`), template name (`TemplateName`), and the user who created the deployment (`CreatedBy`, derived from the deployer's principal name).
* Consolidated custom and inherited tags using the `union` function for comprehensive tagging.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
[Copilot is generating a summary...]