### PR TITLE
feat: Update plan creation to use plan_id in response

### DIFF
--- a/src/frontend/src/api/apiService.tsx
+++ b/src/frontend/src/api/apiService.tsx
@@ -118,8 +118,8 @@ export class APIService {
     //     return apiClient.post(API_ENDPOINTS.PROCESS_REQUEST, inputTask);
     // }
 
-    async createPlan(inputTask: InputTask): Promise<{ status: string; session_id: string }> {
-    return apiClient.post(API_ENDPOINTS.PROCESS_REQUEST, inputTask);
+    async createPlan(inputTask: InputTask): Promise<InputTaskResponse> {
+        return apiClient.post(API_ENDPOINTS.PROCESS_REQUEST, inputTask);
     }
 
     /**

--- a/src/frontend/src/components/content/HomeInput.tsx
+++ b/src/frontend/src/components/content/HomeInput.tsx
@@ -13,11 +13,9 @@ import "../../styles/prism-material-oceanic.css";
 import "./../../styles/HomeInput.css";
 
 import { HomeInputProps, iconMap, QuickTask } from "../../models/homeInput";
-import { TeamConfig } from "../../models/Team";
 import { TaskService } from "../../services/TaskService";
 import { NewTaskService } from "../../services/NewTaskService";
 import { RAIErrorCard, RAIErrorData } from "../errors";
-import { apiService } from "../../api/apiService";
 
 import ChatInput from "@/coral/modules/ChatInput";
 import InlineToaster, { useInlineToaster } from "../toast/InlineToaster";
@@ -78,29 +76,24 @@ const HomeInput: React.FC<HomeInputProps> = ({
                     input.trim(),
                     selectedTeam?.team_id
                 );
+                console.log("Plan created:", response);
                 setInput("");
 
                 if (textareaRef.current) {
                     textareaRef.current.style.height = "auto";
                 }
 
-                if (response.session_id && response.session_id !== null) {
+                if (response.plan_id && response.plan_id !== null) {
                     showToast("Plan created!", "success");
                     dismissToast(id);
 
-                    // Navigate to create page (no team ID in URL anymore)
-                    console.log('HomeInput: Navigating to plan creation with team:', selectedTeam?.name);
-                     console.log('HomeInput: Navigating to plan creation with session:', response.session_id);
-                      console.log('HomeInput: Plan created with session:', response.session_id);
-
-                    navigate(`/plan/${response.session_id}`);
+                    navigate(`/plan/${response.plan_id}`);
                 } else {
                     showToast("Failed to create plan", "error");
                     dismissToast(id);
                 }
             } catch (error: any) {
                 dismissToast(id);
-
                 // Check if this is an RAI validation error
                 let errorDetail = null;
                 try {

--- a/src/frontend/src/services/TaskService.tsx
+++ b/src/frontend/src/services/TaskService.tsx
@@ -206,7 +206,7 @@ export class TaskService {
   static async createPlan(
     description: string,
     teamId?: string
-  ): Promise<{ status: string; session_id: string }> {
+  ): Promise<InputTaskResponse> {
     const sessionId = this.generateSessionId();
 
     const inputTask: InputTask = {


### PR DESCRIPTION
Refactored APIService and TaskService to return InputTaskResponse instead of a session_id. Updated HomeInput to navigate using plan_id from the response and adjusted toast messages accordingly.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->