### PR TITLE
Remove sessionId parameter from selectTeam calls

### DIFF
--- a/src/frontend/src/components/common/TeamSelector.tsx
+++ b/src/frontend/src/components/common/TeamSelector.tsx
@@ -135,7 +135,7 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
 
     try {
       // Call the backend API to select the team
-      const result = await TeamService.selectTeam(tempSelectedTeam.team_id, sessionId);
+      const result = await TeamService.selectTeam(tempSelectedTeam.team_id);
 
       if (result.success) {
         // Successfully selected team on backend

--- a/src/frontend/src/hooks/useTeamSelection.tsx
+++ b/src/frontend/src/hooks/useTeamSelection.tsx
@@ -37,35 +37,35 @@ export const useTeamSelection = ({
 
     try {
       console.log('Selecting team:', team.name, 'with session ID:', sessionId);
-      
-      const result = await TeamService.selectTeam(team.team_id, sessionId);
-      
+
+      const result = await TeamService.selectTeam(team.team_id);
+
       if (result.success) {
         setSelectedTeam(team);
         console.log('Team selection successful:', result.data);
-        
+
         // Call success callback
         onTeamSelected?.(team, result.data);
-        
+
         return true;
       } else {
         const errorMessage = result.error || 'Failed to select team';
         setError(errorMessage);
-        
+
         // Call error callback
         onError?.(errorMessage);
-        
+
         return false;
       }
     } catch (err: any) {
       const errorMessage = err.message || 'Failed to select team';
       setError(errorMessage);
-      
+
       console.error('Team selection error:', err);
-      
+
       // Call error callback
       onError?.(errorMessage);
-      
+
       return false;
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
Updated TeamService.selectTeam invocations in TeamSelector and useTeamSelection to no longer pass the sessionId argument, reflecting a change in the service API.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->