### PR TITLE
fix: Added the user_id explicitly to get the completed task

### DIFF
--- a/src/backend/common/database/cosmosdb.py
+++ b/src/backend/common/database/cosmosdb.py
@@ -235,11 +235,11 @@ class CosmosDBClient(DatabaseBase):
         return await self.query_items(query, parameters, Plan)
 
 
-    async def get_all_plans_by_team_id_status(self, team_id: str, status: str) -> List[Plan]:
+    async def get_all_plans_by_team_id_status(self, user_id: str,team_id: str, status: str) -> List[Plan]:
         """Retrieve all plans for a specific team."""
         query = "SELECT * FROM c WHERE c.team_id=@team_id AND c.data_type=@data_type and c.user_id=@user_id and c.overall_status=@status ORDER BY c._ts DESC"
         parameters = [
-            {"name": "@user_id", "value": self.user_id},
+            {"name": "@user_id", "value": user_id},
             {"name": "@team_id", "value": team_id},
             {"name": "@data_type", "value": DataType.plan},
             {"name": "@status", "value": status},

--- a/src/backend/common/database/database_base.py
+++ b/src/backend/common/database/database_base.py
@@ -93,7 +93,7 @@ class DatabaseBase(ABC):
 
     @abstractmethod
     async def get_all_plans_by_team_id_status(
-        self, team_id: str, status: str
+        self, user_id:str, team_id: str, status: str
     ) -> List[Plan]:
         """Retrieve all plans for a specific team."""
         pass

--- a/src/backend/v3/api/router.py
+++ b/src/backend/v3/api/router.py
@@ -1214,7 +1214,7 @@ async def get_plans(request: Request):
         return []
 
     all_plans = await memory_store.get_all_plans_by_team_id_status(
-        team_id=current_team.team_id, status=PlanStatus.completed
+        user_id=user_id, team_id=current_team.team_id, status=PlanStatus.completed
     )
 
     return all_plans


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates the way plans are retrieved by team and status to require a `user_id` parameter instead of relying on an internal value. The change ensures that queries for plans are correctly filtered by user, improving data accuracy and consistency across the API and database layers.

**Database and API consistency improvements:**

* Updated the abstract method signature in `database_base.py` to require a `user_id` parameter for retrieving plans by team and status, ensuring all implementations follow the same contract.
* Modified the implementation in `cosmosdb.py` to accept `user_id` as an argument and use it in the query parameters, rather than relying on an internal instance value.
* Updated the API endpoint in `router.py` to pass the `user_id` argument when retrieving completed plans for a team, aligning the API usage with the updated method signature.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->