### PR TITLE
fix: Dev to macae-v2 branch

### DIFF
--- a/.github/workflows/deploy-waf.yml
+++ b/.github/workflows/deploy-waf.yml
@@ -105,6 +105,9 @@ jobs:
         id: deploy
         run: |
           set -e
+           # Generate current timestamp in desired format: YYYY-MM-DDTHH:MM:SS.SSSSSSSZ
+            current_date=$(date -u +"%Y-%m-%dT%H:%M:%S.%7NZ")
+          
           az deployment group create \
             --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
             --template-file infra/main.bicep \
@@ -118,6 +121,7 @@ jobs:
               enablePrivateNetworking=true \
               enableScalability=true \
               createdBy="Pipeline" \
+              tags="{'SecurityControl':'Ignore','Purpose':'Deploying and Cleaning Up Resources for Validation','CreatedDate':'$current_date'}"
               
 
       - name: Send Notification on Failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,9 @@ jobs:
             IMAGE_TAG="latest"
           fi
 
+          # Generate current timestamp in desired format: YYYY-MM-DDTHH:MM:SS.SSSSSSSZ
+            current_date=$(date -u +"%Y-%m-%dT%H:%M:%S.%7NZ")
+
           az deployment group create \
             --resource-group ${{ env.RESOURCE_GROUP_NAME }} \
             --template-file infra/main.bicep \
@@ -138,6 +141,7 @@ jobs:
               azureAiServiceLocation='${{ env.AZURE_LOCATION }}' \
               gptModelCapacity=150 \
               createdBy="Pipeline" \
+              tags="{'SecurityControl':'Ignore','Purpose':'Deploying and Cleaning Up Resources for Validation','CreatedDate':'$current_date'}" \
             --output json
 
       - name: Extract Web App and API App URLs

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -180,6 +180,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
     tags: {
       ...allTags
       TemplateName: 'MACAE'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
     }
   }


### PR DESCRIPTION
## Purpose
This pull request updates the logic for setting the `createdBy` tag in the `infra/main.bicep` file. The main improvement is to make the assignment of the `createdBy` parameter more robust by handling cases where `userPrincipalName` may not be present in the deployer object.

Tag assignment improvement:

* Updated the `createdBy` parameter to check if `userPrincipalName` exists in the `deployer()` object. If it does, it uses the username portion before the `@`; otherwise, it falls back to using the `objectId` of the deployer. This ensures the tag is always set with meaningful information, even if the user principal name is missing.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->