### PR TITLE
refactor: removes the use of `contextvars` and refactors the codebase to explicitly pass `user_id`

### DIFF
--- a/src/backend/v3/callbacks/response_handlers.py
+++ b/src/backend/v3/callbacks/response_handlers.py
@@ -10,7 +10,7 @@ import time
 
 from semantic_kernel.contents import (ChatMessageContent,
                                       StreamingChatMessageContent)
-from v3.config.settings import connection_config, current_user_id
+from v3.config.settings import connection_config
 from v3.models.messages import (AgentMessage, AgentMessageStreaming,
                                 AgentToolCall, AgentToolMessage, WebsocketMessageType)
 

--- a/src/backend/v3/config/settings.py
+++ b/src/backend/v3/config/settings.py
@@ -4,7 +4,6 @@ Handles Azure OpenAI, MCP, and environment setup.
 """
 
 import asyncio
-import contextvars
 import json
 import logging
 from typing import Dict, Optional
@@ -18,11 +17,6 @@ from semantic_kernel.connectors.ai.open_ai import (
 from v3.models.messages import WebsocketMessageType, MPlan
 
 logger = logging.getLogger(__name__)
-
-# Create a context variable to track current user
-current_user_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
-    "current_user_id", default=None
-)
 
 
 class AzureConfig:
@@ -177,13 +171,10 @@ class ConnectionConfig:
     async def send_status_update_async(
         self,
         message: any,
-        user_id: Optional[str] = None,
+        user_id: str,
         message_type: WebsocketMessageType = WebsocketMessageType.SYSTEM_MESSAGE,
     ):
         """Send a status update to a specific client."""
-        # If no process_id provided, get from context
-        if user_id is None:
-            user_id = current_user_id.get()
 
         if not user_id:
             logger.warning("No user_id available for WebSocket message")

--- a/src/backend/v3/magentic_agents/magentic_agent_factory.py
+++ b/src/backend/v3/magentic_agents/magentic_agent_factory.py
@@ -10,7 +10,6 @@ from typing import List, Union
 
 from common.config.app_config import config
 from common.models.messages_kernel import TeamConfiguration
-from v3.config.settings import current_user_id
 from v3.magentic_agents.foundry_agent import FoundryAgentTemplate
 from v3.magentic_agents.models.agent_models import MCPConfig, SearchConfig
 # from v3.magentic_agents.models.agent_models import (BingConfig, MCPConfig,
@@ -42,12 +41,13 @@ class MagenticAgentFactory:
     #     with open(file_path, 'r') as f:
     #         data = json.load(f)
     #     return json.loads(json.dumps(data), object_hook=lambda d: SimpleNamespace(**d))
-    
-    async def create_agent_from_config(self, agent_obj: SimpleNamespace) -> Union[FoundryAgentTemplate, ReasoningAgentTemplate, ProxyAgent]:
+
+    async def create_agent_from_config(self, user_id: str, agent_obj: SimpleNamespace) -> Union[FoundryAgentTemplate, ReasoningAgentTemplate, ProxyAgent]:
         """
         Create an agent from configuration object.
         
         Args:
+            user_id: User ID
             agent_obj: Agent object from parsed JSON (SimpleNamespace)
             team_model: Model name to determine which template to use
             
@@ -63,7 +63,6 @@ class MagenticAgentFactory:
 
         if not deployment_name and agent_obj.name.lower() == "proxyagent":
             self.logger.info("Creating ProxyAgent")
-            user_id = current_user_id.get()
             return ProxyAgent(user_id=user_id)
         
         # Validate supported models
@@ -124,11 +123,12 @@ class MagenticAgentFactory:
         self.logger.info(f"Successfully created and initialized agent '{agent_obj.name}'")
         return agent
 
-    async def get_agents(self, team_config_input: TeamConfiguration) -> List:
+    async def get_agents(self, user_id: str, team_config_input: TeamConfiguration) -> List:
         """
         Create and return a team of agents from JSON configuration.
         
         Args:
+            user_id: User ID
             team_config_input: team configuration object from cosmos db
             
         Returns:
@@ -143,8 +143,8 @@ class MagenticAgentFactory:
             for i, agent_cfg in enumerate(team_config_input.agents, 1):
                 try:
                     self.logger.info(f"Creating agent {i}/{len(team_config_input.agents)}: {agent_cfg.name}")
-                    
-                    agent = await self.create_agent_from_config(agent_cfg)
+
+                    agent = await self.create_agent_from_config(user_id, agent_cfg)
                     initalized_agents.append(agent)
                     self._agent_list.append(agent)  # Keep track for cleanup
                     

--- a/src/backend/v3/magentic_agents/proxy_agent.py
+++ b/src/backend/v3/magentic_agents/proxy_agent.py
@@ -21,8 +21,7 @@ from semantic_kernel.exceptions.agent_exceptions import \
 from typing_extensions import override
 from v3.callbacks.response_handlers import (agent_response_callback,
                                             streaming_agent_response_callback)
-from v3.config.settings import (connection_config, current_user_id,
-                                orchestration_config)
+from v3.config.settings import connection_config, orchestration_config
 from v3.models.messages import (UserClarificationRequest,
                                 UserClarificationResponse, WebsocketMessageType)
 
@@ -94,11 +93,11 @@ class ProxyAgent(Agent):
     """Simple proxy agent that prompts for human clarification."""
 
     # Declare as Pydantic field
-    user_id: Optional[str] = Field(default=None, description="User ID for WebSocket messaging")
+    user_id: str = Field(default=None, description="User ID for WebSocket messaging")
     
-    def __init__(self, user_id: str = None, **kwargs):
-        # Get user_id from parameter or context, fallback to empty string
-        effective_user_id = user_id or current_user_id.get() or ""
+    def __init__(self, user_id: str, **kwargs):
+        # Get user_id from parameter, fallback to empty string
+        effective_user_id = user_id or ""
         super().__init__(
             name="ProxyAgent",
             description="Call this agent when you need to clarify requests by asking the human user for more information. Ask it for more details about any unclear requirements, missing information, or if you need the user to elaborate on any aspect of the task.",
@@ -119,7 +118,7 @@ class ProxyAgent(Agent):
     async def _trigger_response_callbacks(self, message_content: ChatMessageContent):
         """Manually trigger the same response callbacks used by other agents."""
                 # Get current user_id dynamically instead of using stored value
-        current_user = current_user_id.get() or self.user_id or ""
+        current_user = self.user_id or ""
 
         # Trigger the standard agent response callback
         agent_response_callback(message_content, current_user)
@@ -127,7 +126,7 @@ class ProxyAgent(Agent):
     async def _trigger_streaming_callbacks(self, content: str, is_final: bool = False):
         """Manually trigger streaming callbacks for real-time updates."""
         # Get current user_id dynamically instead of using stored value
-        current_user = current_user_id.get() or self.user_id or ""
+        current_user = self.user_id or ""
         streaming_message = StreamingChatMessageContent(
             role=AuthorRole.ASSISTANT,
             content=content,
@@ -158,7 +157,7 @@ class ProxyAgent(Agent):
         await connection_config.send_status_update_async({
             "type": WebsocketMessageType.USER_CLARIFICATION_REQUEST,
             "data": clarification_message
-        }, user_id=current_user_id.get(), message_type=WebsocketMessageType.USER_CLARIFICATION_REQUEST)
+        }, user_id=self.user_id, message_type=WebsocketMessageType.USER_CLARIFICATION_REQUEST)
 
         # Get human input
         human_response = await self._wait_for_user_clarification(clarification_message.request_id)
@@ -206,7 +205,7 @@ class ProxyAgent(Agent):
         await connection_config.send_status_update_async({
             "type": WebsocketMessageType.USER_CLARIFICATION_REQUEST, 
             "data": clarification_message
-        }, user_id=current_user_id.get(), message_type=WebsocketMessageType.USER_CLARIFICATION_REQUEST)
+        }, user_id=self.user_id, message_type=WebsocketMessageType.USER_CLARIFICATION_REQUEST)
 
         # Get human input - replace with websocket call when available
         human_response = await self._wait_for_user_clarification(clarification_message.request_id)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request removes the use of `contextvars` for tracking the current user ID throughout the backend orchestration and agent code. Instead, it refactors the codebase to explicitly pass `user_id` as a function argument or class field wherever needed. This change improves clarity, reduces hidden dependencies, and makes the user context handling more robust and maintainable.

**Refactoring user context handling:**

* Removed all usages and imports of `contextvars` and the `current_user_id` variable from `settings.py`, `router.py`, agent, and orchestration modules, replacing them with explicit `user_id` parameters and fields. [[1]](diffhunk://#diff-6426b06c93613bacee7d55df36bd8d7dbe99898f4472d899ebadfc90c79f545eL2) [[2]](diffhunk://#diff-be0a4e10a008c53a5e420f18156708fad0c616a072f36d1cc41cbf1bac6239b9L22-L26) [[3]](diffhunk://#diff-9be68eb12aa1ed77ed23d93a80bbc0f375e46a04c6a64eb79a384f0fc5296008L5-L9) [[4]](diffhunk://#diff-9be68eb12aa1ed77ed23d93a80bbc0f375e46a04c6a64eb79a384f0fc5296008L24-L33) [[5]](diffhunk://#diff-fd8cbc687fa5256543b02db98ae718cfb9f761382d0bc0817190f8018b6b886dL24-R24) [[6]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L19-R19) [[7]](diffhunk://#diff-4ca122ab9c64a46f236ea7f02a3833d262017a3e278e39a35c7d96ac0623d1b7L13)
* Updated all function and class signatures to require `user_id` as an argument, including agent creation (`create_agent_from_config`, `get_agents`), agent invocation, and orchestration manager initialization. [[1]](diffhunk://#diff-4ca122ab9c64a46f236ea7f02a3833d262017a3e278e39a35c7d96ac0623d1b7L46-R50) [[2]](diffhunk://#diff-4ca122ab9c64a46f236ea7f02a3833d262017a3e278e39a35c7d96ac0623d1b7L127-R131) [[3]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L38-L40)
* Refactored the `ProxyAgent` and `HumanApprovalMagenticManager` classes to store and use `user_id` directly, removing reliance on global context. [[1]](diffhunk://#diff-fd8cbc687fa5256543b02db98ae718cfb9f761382d0bc0817190f8018b6b886dL97-R100) [[2]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L38-L40)

**WebSocket connection and messaging updates:**

* Changed connection cleanup and status update logic to use `process_id` and explicit `user_id` parameters instead of context-based retrieval. [[1]](diffhunk://#diff-6426b06c93613bacee7d55df36bd8d7dbe99898f4472d899ebadfc90c79f545eL77-R74) [[2]](diffhunk://#diff-be0a4e10a008c53a5e420f18156708fad0c616a072f36d1cc41cbf1bac6239b9L180-L186)
* Updated all WebSocket message sending and callback invocations to use the passed `user_id` rather than fetching from context, ensuring correct routing of messages to users. [[1]](diffhunk://#diff-fd8cbc687fa5256543b02db98ae718cfb9f761382d0bc0817190f8018b6b886dL161-R160) [[2]](diffhunk://#diff-fd8cbc687fa5256543b02db98ae718cfb9f761382d0bc0817190f8018b6b886dL209-R208) [[3]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L118-R127) [[4]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L132-R141) [[5]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L157-R166)

**Background orchestration and agent initialization:**

* Simplified background task orchestration by removing context copying and instead passing `user_id` directly to orchestration routines and agent factories. [[1]](diffhunk://#diff-6426b06c93613bacee7d55df36bd8d7dbe99898f4472d899ebadfc90c79f545eL291-R295) [[2]](diffhunk://#diff-4ca122ab9c64a46f236ea7f02a3833d262017a3e278e39a35c7d96ac0623d1b7L147-R147) [[3]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463R80-R81) [[4]](diffhunk://#diff-8193bc7a6c8c05b58b15b77279739cbfe2cd177321f980850234d1cd21878463L97-R106)

These changes make the user context handling explicit and more reliable, reducing the risk of subtle bugs and improving code readability.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->