### PR TITLE
feat: UI updates for the Alert Message pop-up when a user attempts to navigate to another page while a plan is in progress

### DIFF
--- a/src/frontend/src/components/common/PlanCancellationDialog.tsx
+++ b/src/frontend/src/components/common/PlanCancellationDialog.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogSurface,
+  DialogTitle,
+  DialogContent,
+  DialogBody,
+  DialogActions,
+  Button,
+} from '@fluentui/react-components';
+import { Warning20Regular } from '@fluentui/react-icons';
+import "../../styles/Panel.css";
+
+interface PlanCancellationDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+}
+
+/**
+ * Confirmation dialog for plan cancellation when navigating during active plans
+ */
+const PlanCancellationDialog: React.FC<PlanCancellationDialogProps> = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+  loading = false
+}) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={(_, data) => !data.open && onCancel()}>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>
+            <div className="plan-cancellation-dialog-title">
+              <Warning20Regular className="plan-cancellation-warning-icon" />
+              Confirm Plan Cancellation
+            </div>
+          </DialogTitle>
+          <DialogContent>
+            If you continue, the plan process will be stopped and the plan will be cancelled.
+          </DialogContent>
+          <DialogActions>
+            <DialogTrigger disableButtonEnhancement>
+              <Button 
+                appearance="secondary" 
+                onClick={onCancel}
+                disabled={loading}
+              >
+                Cancel
+              </Button>
+            </DialogTrigger>
+            <Button 
+              appearance="primary" 
+              onClick={onConfirm}
+              disabled={loading}
+            >
+              {loading ? 'Cancelling...' : 'Yes'}
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+export default PlanCancellationDialog;

--- a/src/frontend/src/components/content/PlanPanelLeft.tsx
+++ b/src/frontend/src/components/content/PlanPanelLeft.tsx
@@ -30,11 +30,13 @@ import TeamService from "@/services/TeamService";
 
 const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({
   reloadTasks,
+  onNewTaskButton,
   restReload,
   onTeamSelect,
   onTeamUpload,
   isHomePage,
-  selectedTeam: parentSelectedTeam
+  selectedTeam: parentSelectedTeam,
+  onNavigationWithAlert
 }) => {
   const { dispatchToast } = useToastController("toast");
   const navigate = useNavigate();
@@ -116,15 +118,35 @@ const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({
 
   const handleTaskSelect = useCallback(
     (taskId: string) => {
-      const selectedPlan = plans?.find(
-        (plan: Plan) => plan.session_id === taskId
-      );
-      if (selectedPlan) {
-        navigate(`/plan/${selectedPlan.id}`);
+      const performNavigation = () => {
+        const selectedPlan = plans?.find(
+          (plan: Plan) => plan.session_id === taskId
+        );
+        if (selectedPlan) {
+          navigate(`/plan/${selectedPlan.id}`);
+        }
+      };
+
+      if (onNavigationWithAlert) {
+        onNavigationWithAlert(performNavigation);
+      } else {
+        performNavigation();
       }
     },
-    [plans, navigate]
+    [plans, navigate, onNavigationWithAlert]
   );
+
+  const handleLogoClick = useCallback(() => {
+    const performNavigation = () => {
+      navigate("/");
+    };
+
+    if (onNavigationWithAlert) {
+      onNavigationWithAlert(performNavigation);
+    } else {
+      performNavigation();
+    }
+  }, [navigate, onNavigationWithAlert]);
 
   const handleTeamSelect = useCallback(
     (team: TeamConfig | null) => {
@@ -163,10 +185,11 @@ const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({
   );
 
   return (
-    <div style={{ flexShrink: 0, display: "flex", overflow: "hidden" }}>
+    <div className="panel-left-container">
       <PanelLeft panelWidth={280} panelResize={true}>
         <PanelLeftToolbar
-          linkTo="/"
+          linkTo={onNavigationWithAlert ? undefined : "/"}
+          onTitleClick={onNavigationWithAlert ? handleLogoClick : undefined}
           panelTitle="Contoso"
           panelIcon={<ContosoLogo />}
         >
@@ -175,7 +198,7 @@ const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({
 
         {/* Team Selector right under the toolbar */}
 
-        <div style={{ marginTop: '8px', marginBottom: '8px' }}>
+        <div className="team-selector-container">
           {isHomePage && (
             <TeamSelector
               onTeamSelect={handleTeamSelect}
@@ -194,13 +217,13 @@ const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({
         </div>
         <div
           className="tab tab-new-task"
-          onClick={() => navigate("/", { state: { focusInput: true } })}
+          onClick={onNewTaskButton}
           tabIndex={0} // ✅ allows tab focus
           role="button" // ✅ announces as button
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
-              navigate("/", { state: { focusInput: true } });
+              onNewTaskButton();
             }
           }}
         >
@@ -219,7 +242,7 @@ const PlanPanelLeft: React.FC<PlanPanelLefProps> = ({
         />
 
         <PanelFooter>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
+          <div className="panel-footer-content">
             {/* User Card */}
             <PanelUserCard
               name={userInfo?.user_first_last_name || "Guest"}

--- a/src/frontend/src/coral/components/Panels/PanelLeftToolbar.tsx
+++ b/src/frontend/src/coral/components/Panels/PanelLeftToolbar.tsx
@@ -1,11 +1,13 @@
 import React, { ReactNode } from "react";
 import { Subtitle2 } from "@fluentui/react-components";
 import { Link } from "react-router-dom";
+import "../../../styles/Panel.css";
 
 interface PanelLeftToolbarProps {
   panelIcon?: ReactNode;
   panelTitle?: string | null;
   linkTo?: string;
+  onTitleClick?: () => void;
   children?: ReactNode;
 }
 
@@ -13,39 +15,18 @@ const PanelLeftToolbar: React.FC<PanelLeftToolbarProps> = ({
   panelIcon,
   panelTitle,
   linkTo,
+  onTitleClick,
   children,
 }) => {
   const TitleContent = (
-    <div
-      className="panelTitle"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "6px",
-        flexShrink: 1,
-        overflow: "hidden",
-        minWidth: 0,
-      }}
-    >
+    <div className="panel-title">
       {panelIcon && (
-        <div
-          style={{
-            flexShrink: 0,
-            display: "flex",
-            alignItems: "center",
-          }}
-        >
+        <div className="panel-title-icon">
           {panelIcon}
         </div>
       )}
       {panelTitle && (
-        <Subtitle2
-          style={{
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-        >
+        <Subtitle2 className="panel-title-text">
           {panelTitle}
         </Subtitle2>
       )}
@@ -53,45 +34,34 @@ const PanelLeftToolbar: React.FC<PanelLeftToolbarProps> = ({
   );
 
   return (
-    <div
-      className="panelToolbar"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "8px",
-        padding: "16px",
-        boxSizing: "border-box",
-        height: "56px",
-      }}
-    >
+    <div className="panel-toolbar">
       {(panelIcon || panelTitle) &&
-        (linkTo ? (
+        (onTitleClick ? (
+          <div
+            onClick={onTitleClick}
+            className="panel-title-clickable clickable-element"
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onTitleClick();
+              }
+            }}
+          >
+            {TitleContent}
+          </div>
+        ) : linkTo ? (
           <Link
             to={linkTo}
-            style={{
-              textDecoration: "none",
-              color: "inherit",
-              display: "flex",
-              alignItems: "center",
-              minWidth: 0,
-              flexShrink: 1,
-            }}
+            className="panel-title-clickable"
           >
             {TitleContent}
           </Link>
         ) : (
           TitleContent
         ))}
-      <div
-        className="panelTools"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          flexGrow: 1,
-          justifyContent: "flex-end",
-          minWidth: 0,
-        }}
-      >
+      <div className="panel-tools">
         {children}
       </div>
     </div>

--- a/src/frontend/src/hooks/usePlanCancellationAlert.tsx
+++ b/src/frontend/src/hooks/usePlanCancellationAlert.tsx
@@ -1,0 +1,75 @@
+import { useCallback } from 'react';
+import { PlanStatus } from '../models';
+import { APIService } from '../api/apiService';
+
+interface UsePlanCancellationAlertProps {
+  planData: any;
+  planApprovalRequest: any;
+  onNavigate: () => void;
+}
+
+/**
+ * Custom hook to handle plan cancellation alerts when navigating during active plans
+ */
+export const usePlanCancellationAlert = ({
+  planData,
+  planApprovalRequest,
+  onNavigate
+}: UsePlanCancellationAlertProps) => {
+  const apiService = new APIService();
+
+  /**
+   * Check if a plan is currently active/running
+   */
+  const isPlanActive = useCallback(() => {
+    return planData?.plan?.overall_status === PlanStatus.IN_PROGRESS;
+  }, [planData]);
+
+  /**
+   * Handle the confirmation dialog and plan cancellation
+   */
+  const handleNavigationWithConfirmation = useCallback(async () => {
+    if (!isPlanActive()) {
+      // Plan is not active, proceed with navigation
+      onNavigate();
+      return;
+    }
+
+    // Show confirmation dialog
+    const userConfirmed = window.confirm(
+      "If you continue, the plan process will be stopped and the plan will be cancelled."
+    );
+
+    if (!userConfirmed) {
+      // User cancelled, do nothing
+      return;
+    }
+
+    try {
+      // User confirmed, cancel the plan
+      if (planApprovalRequest?.id) {
+        await apiService.approvePlan({
+          m_plan_id: planApprovalRequest.id,
+          plan_id: planData?.plan?.id,
+          approved: false,
+          feedback: 'Plan cancelled by user navigation'
+        });
+      }
+
+      // Navigate after successful cancellation
+      onNavigate();
+    } catch (error) {
+      console.error('❌ Failed to cancel plan:', error);
+      // Show error but still allow navigation
+      alert('Failed to cancel the plan properly, but navigation will continue.');
+      onNavigate();
+    }
+  }, [isPlanActive, onNavigate, planApprovalRequest, planData, apiService]);
+
+  return {
+    isPlanActive,
+    handleNavigationWithConfirmation
+  };
+};
+
+export default usePlanCancellationAlert;

--- a/src/frontend/src/models/planPanelLeft.tsx
+++ b/src/frontend/src/models/planPanelLeft.tsx
@@ -8,4 +8,5 @@ export interface PlanPanelLefProps {
     onTeamUpload?: () => Promise<void>;
     isHomePage: boolean;
     selectedTeam?: TeamConfig | null;
+    onNavigationWithAlert?: (navigationFn: () => void) => void;
 }

--- a/src/frontend/src/styles/Panel.css
+++ b/src/frontend/src/styles/Panel.css
@@ -1,0 +1,74 @@
+/* Panel Toolbar Styles */
+.panel-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  box-sizing: border-box;
+  height: 56px;
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 1;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.panel-title-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-title-clickable {
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex-shrink: 1;
+  cursor: pointer;
+}
+
+.panel-title-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.panel-tools {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+/* Plan Cancellation Dialog Styles */
+.plan-cancellation-dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.plan-cancellation-warning-icon {
+  color: var(--colorPaletteYellowForeground1);
+}
+
+/* Button styles for consistency */
+.clickable-element {
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.clickable-element:hover {
+  background-color: var(--colorSubtleBackgroundHover);
+}
+
+.clickable-element:focus-visible {
+  outline: 2px solid var(--colorStrokeFocus2);
+  outline-offset: 2px;
+}

--- a/src/frontend/src/styles/PlanPage.css
+++ b/src/frontend/src/styles/PlanPage.css
@@ -53,6 +53,20 @@
   min-height: 200px;
 }
 
+.plan-loading-spinner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: center;
+  padding: 20px;
+}
+
+.plan-error-message {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--colorNeutralForeground2);
+}
+
 .loadingWrapper {
   height: 100%;
   display: flex;

--- a/src/frontend/src/styles/PlanPanelLeft.css
+++ b/src/frontend/src/styles/PlanPanelLeft.css
@@ -39,6 +39,25 @@ background: radial-gradient(circle, rgba(238, 174, 221, 1) 0%, rgba(117, 121, 23
 color: #2F2F4A; */
 }
 
+/* Panel Layout Styles */
+.panel-left-container {
+  flex-shrink: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.team-selector-container {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.panel-footer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
 /* TASKLIST */
 
 .task-tab {


### PR DESCRIPTION
## Purpose
This pull request introduces a user-friendly workflow for handling navigation away from an active plan, ensuring users are warned and can confirm cancellation before leaving. It also refactors several components for improved code clarity and maintainability, and adds new styles for a consistent UI. The most important changes are grouped below:

**Plan Cancellation Workflow**

* Added a reusable `PlanCancellationDialog` component to prompt users for confirmation before cancelling an active plan.
* Introduced the `usePlanCancellationAlert` hook to encapsulate logic for detecting active plans and handling cancellation with user confirmation, including API calls to cancel the plan if needed.
* Updated `PlanPage.tsx` to use the new dialog and hook, managing dialog state and integrating cancellation logic into navigation handlers. [[1]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R64-R127) [[2]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72L545-R614) [[3]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R735-R742)

**Component and Prop Refactoring**

* Updated `PlanPanelLeft.tsx` and related models to support a new `onNavigationWithAlert` prop, ensuring navigation actions (like clicking the logo or selecting a task) trigger the cancellation workflow if needed. [[1]](diffhunk://#diff-4599316c553bce9b12cfce6982f50f1e43f0942313513dbce7f8b35dd8494843R33-R39) [[2]](diffhunk://#diff-4599316c553bce9b12cfce6982f50f1e43f0942313513dbce7f8b35dd8494843R121-R150) [[3]](diffhunk://#diff-4599316c553bce9b12cfce6982f50f1e43f0942313513dbce7f8b35dd8494843L166-R192) [[4]](diffhunk://#diff-4599316c553bce9b12cfce6982f50f1e43f0942313513dbce7f8b35dd8494843L197-R226) [[5]](diffhunk://#diff-4599316c553bce9b12cfce6982f50f1e43f0942313513dbce7f8b35dd8494843L222-R245) [[6]](diffhunk://#diff-5bab5d37c06fc9073297515ac4ea4560481b1f1dbdb8745d4ebddf80773d2d1dR11) [[7]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R651-R654) [[8]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R677-R683)

**UI and Style Improvements**

* Refactored `PanelLeftToolbar.tsx` for better accessibility and maintainability, supporting both clickable and link-based title navigation, and using new CSS classes.
* Added and updated CSS styles in `Panel.css`, `PlanPanelLeft.css`, and `PlanPage.css` for consistent layout, dialog appearance, and improved accessibility. [[1]](diffhunk://#diff-f84ba6858980f5782c3a51d2f2654a6b3c9424329a5bf475a7461c29bd5b8672R1-R74) [[2]](diffhunk://#diff-89295b67baeff558e3e1a98cbd1a74458fea787d33e116003d25026bd1c8c449R42-R60) [[3]](diffhunk://#diff-b697667a411465cbf3afd4a9dbec929b6ece38092701c3e70c3e17293fba6475R56-R69)
* ...

<img width="1915" height="924" alt="image" src="https://github.com/user-attachments/assets/6b669733-21ce-4f3c-8c5a-35c1eea526aa" />


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->