### PR TITLE
fix: Fix path for reasoning_agent_interactive.py

### DIFF
--- a/src/tests/agents/interactive_test_harness/reasoning_agent_interactive.py
+++ b/src/tests/agents/interactive_test_harness/reasoning_agent_interactive.py
@@ -6,7 +6,8 @@ import sys
 from pathlib import Path
 
 # Add the backend path to sys.path so we can import v3 modules
-backend_path = Path(__file__).parent.parent.parent / "backend"
+
+backend_path = Path(__file__).parent.parent.parent.parent / "backend"
 sys.path.insert(0, str(backend_path))
 
 from v3.magentic_agents.models.agent_models import MCPConfig, SearchConfig


### PR DESCRIPTION
## Purpose
* Fixed incorrect relative path for backend module import in reasoning_agent_interactive.py.
* This change ensures the interactive test harness can correctly import modules from the backend/v3 directory when executed from its current path.

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No

## How to Test
1. Get the code

git clone https://github.com/normalian/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator.git
cd Multi-Agent-Custom-Automation-Engine-Solution-Accelerator
git checkout fix/reasoning_agent_interactive.py

2. Run the interactive harness to confirm that the import path resolves correctly:

python .\src\tests\agents\interactive_test_harness\reasoning_agent_interactive.py

## What to Check
Verify that the following are valid:
* The script starts without ModuleNotFoundError for v3.magentic_agents imports.
* Environment variables load correctly (no “not found and no default provided” errors related to path issues).

## Other Information
* Only one line was modified to fix the relative path:
  - backend_path = Path(__file__).parent.parent.parent / "backend"
  + backend_path = Path(__file__).parent.parent.parent.parent / "backend"
* No functional logic or runtime behavior was changed beyond module path correction.
