### PR TITLE
Pass project_endpoint to agent constructors

### DIFF
--- a/src/backend/common/utils/utils_af.py
+++ b/src/backend/common/utils/utils_af.py
@@ -33,6 +33,7 @@ async def create_RAI_agent() -> FoundryAgentTemplate:
         agent_instructions=agent_instructions,
         model_deployment_name=model_deployment_name,
         enable_code_interpreter=False,
+        project_endpoint=config.AZURE_AI_PROJECT_ENDPOINT,
         mcp_config=None,
         search_config=None,
     )

--- a/src/backend/v4/magentic_agents/common/lifecycle.py
+++ b/src/backend/v4/magentic_agents/common/lifecycle.py
@@ -111,14 +111,15 @@ class AzureAgentBase(MCPEnabledBase):
       - optionally register themselves via agent_registry
     """
 
-    def __init__(self, mcp: MCPConfig | None = None, model_deployment_name: str | None = None) -> None:
+    def __init__(self, mcp: MCPConfig | None = None, model_deployment_name: str | None = None, project_endpoint: str | None = None) -> None:
         super().__init__(mcp=mcp)
         self.creds: Optional[DefaultAzureCredential] = None
         self.client: Optional[AzureAIAgentClient] = None
-        self.project_endpoint: Optional[str] = None
+       
         self._created_ephemeral: bool = (
             False  # reserved if you add ephemeral agent cleanup
         )
+        self.project_endpoint = project_endpoint
         self.model_deployment_name = model_deployment_name
 
     async def open(self) -> "AzureAgentBase":
@@ -126,12 +127,6 @@ class AzureAgentBase(MCPEnabledBase):
             return self
         self._stack = AsyncExitStack()
 
-        # Resolve Azure AI Project endpoint (mirrors old SK env var usage)
-        self.project_endpoint = os.getenv("AZURE_AI_PROJECT_ENDPOINT")
-        if not self.project_endpoint:
-            raise RuntimeError(
-                "AZURE_AI_PROJECT_ENDPOINT environment variable is required for AzureAgentBase."
-            )
 
         # Acquire credential
         self.creds = DefaultAzureCredential()

--- a/src/backend/v4/magentic_agents/foundry_agent.py
+++ b/src/backend/v4/magentic_agents/foundry_agent.py
@@ -33,11 +33,12 @@ class FoundryAgentTemplate(AzureAgentBase):
         agent_description: str,
         agent_instructions: str,
         model_deployment_name: str,
+        project_endpoint: str,
         enable_code_interpreter: bool = False,
         mcp_config: MCPConfig | None = None,
         search_config: SearchConfig | None = None,
     ) -> None:
-        super().__init__(mcp=mcp_config, model_deployment_name=model_deployment_name)
+        super().__init__(mcp=mcp_config, model_deployment_name=model_deployment_name, project_endpoint=project_endpoint)
         self.agent_name = agent_name
         self.agent_description = agent_description
         self.agent_instructions = agent_instructions
@@ -110,10 +111,10 @@ class FoundryAgentTemplate(AzureAgentBase):
         query_type = getattr(self.search, "search_query_type", "vector")
         
         # ai_search_conn_id = ""
-        # async for connection in self.client.project_client.connections.list():
-        #     if connection.type == ConnectionType.AZURE_AI_SEARCH:
-        #         ai_search_conn_id = connection.id
-        #         break
+        async for connection in self.client.project_client.connections.list():
+            if connection.type == ConnectionType.AZURE_AI_SEARCH:
+                connection_id = connection.id
+                break
         if not connection_id or not index_name:
             self.logger.error(
                 "Missing azure_search_connection_id or azure_search_index_name in search_config; aborting Azure Search path."

--- a/src/backend/v4/magentic_agents/magentic_agent_factory.py
+++ b/src/backend/v4/magentic_agents/magentic_agent_factory.py
@@ -118,6 +118,7 @@ class MagenticAgentFactory:
                 agent_instructions=getattr(agent_obj, "system_message", ""),
                 model_deployment_name=deployment_name,
                 enable_code_interpreter=getattr(agent_obj, "coding_tools", False),
+                project_endpoint=config.AZURE_AI_PROJECT_ENDPOINT,
                 mcp_config=mcp_config,
                 search_config=search_config,
             )


### PR DESCRIPTION
Updated agent creation logic to explicitly pass the Azure AI project endpoint from config to agent constructors. Refactored AzureAgentBase to accept project_endpoint as an argument instead of reading from the environment variable. Also enabled Azure Search connection lookup in FoundryAgentTemplate.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->