### PR TITLE
Remove HTML escaping from config environment variables

### DIFF
--- a/src/frontend/frontend_server.py
+++ b/src/frontend/frontend_server.py
@@ -37,8 +37,8 @@ async def serve_index():
 
 @app.get("/config")
 async def get_config():
-    backend_url = html.escape(os.getenv("BACKEND_API_URL", "http://localhost:8000"))
-    auth_enabled = html.escape(os.getenv("AUTH_ENABLED", "false"))
+    backend_url = os.getenv("BACKEND_API_URL", "http://localhost:8000")
+    auth_enabled = os.getenv("AUTH_ENABLED", "false")
     backend_url = backend_url + "/api"
 
     config = {
@@ -53,11 +53,17 @@ async def serve_app(full_path: str):
     # Remediation: normalize and check containment before serving
     file_path = os.path.normpath(os.path.join(BUILD_DIR, full_path))
     # Block traversal and dotfiles
-    if not file_path.startswith(BUILD_DIR) or ".." in full_path or "/." in full_path or "\\." in full_path:
+    if (
+        not file_path.startswith(BUILD_DIR)
+        or ".." in full_path
+        or "/." in full_path
+        or "\\." in full_path
+    ):
         return FileResponse(INDEX_HTML)
     if os.path.isfile(file_path):
         return FileResponse(file_path)
     return FileResponse(INDEX_HTML)
+
 
 if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=3000, access_log=False, log_level="info")


### PR DESCRIPTION
The /config endpoint no longer applies html.escape to BACKEND_API_URL and AUTH_ENABLED environment variables. This change ensures the values are returned as-is, which is more appropriate for non-HTML config data.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->