### PR TITLE
fix: Macaev4 AVM Post deployment script changes

### DIFF
--- a/docs/AVMPostDeploymentGuide.md
+++ b/docs/AVMPostDeploymentGuide.md
@@ -83,12 +83,12 @@ The post-deployment process is automated through a single PowerShell or Bash scr
    - **For PowerShell (Windows/Linux/macOS):**
 
      ```powershell
-     .\infra\scripts\Team-Config-And-Data.ps1 -ResourceGroup "<your-resource-group-name>"
+     infra\scripts\Selecting-Team-Config-And-Data.ps1 -ResourceGroup "<your-resource-group-name>"
      ```
 
    - **For Bash (Linux/macOS/WSL):**
      ```bash
-     bash infra/scripts/team_config_and_data.sh "<your-resource-group-name>"
+     bash infra/scripts/selecting_team_config_and_data.sh --resource-group "<your-resource-group-name>"
      ```
 
    **If you deployed using `azd up` command:**
@@ -96,12 +96,12 @@ The post-deployment process is automated through a single PowerShell or Bash scr
    - **For PowerShell (Windows/Linux/macOS):**
 
      ```powershell
-     .\infra\scripts\Team-Config-And-Data.ps1
+     infra\scripts\Selecting-Team-Config-And-Data.ps1
      ```
 
    - **For Bash (Linux/macOS/WSL):**
      ```bash
-     bash infra/scripts/team_config_and_data.sh
+     bash infra/scripts/selecting_team_config_and_data.sh
      ```
 
    > **Note**: Replace `<your-resource-group-name>` with the actual name of the resource group containing your deployed Azure resources.

--- a/infra/scripts/Selecting-Team-Config-And-Data.ps1
+++ b/infra/scripts/Selecting-Team-Config-And-Data.ps1
@@ -76,6 +76,28 @@ function Get-ValuesFromAzdEnv {
     return $true
 }
 
+function Get-DeploymentValue {
+    param(
+        [object]$DeploymentOutputs,
+        [string]$PrimaryKey,
+        [string]$FallbackKey
+    )
+    
+    $value = $null
+    
+    # Try primary key first
+    if ($DeploymentOutputs.PSObject.Properties[$PrimaryKey]) {
+        $value = $DeploymentOutputs.$PrimaryKey.value
+    }
+    
+    # If primary key failed, try fallback key
+    if (-not $value -and $DeploymentOutputs.PSObject.Properties[$FallbackKey]) {
+        $value = $DeploymentOutputs.$FallbackKey.value
+    }
+    
+    return $value
+}
+
 function Get-ValuesFromAzDeployment {
     Write-Host "Getting values from Azure deployment outputs..."
     
@@ -95,30 +117,29 @@ function Get-ValuesFromAzDeployment {
         return $false
     }
     
-    # Extract specific outputs
-    $script:storageAccount = $deploymentOutputs.azurE_STORAGE_ACCOUNT_NAME.value
-    # $script:blobContainer = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME.value
-    $script:blobContainerForRetailCustomer = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_RETAIL_CUSTOMER.value
-    $script:blobContainerForRetailOrder = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_RETAIL_ORDER.value
-    $script:blobContainerForRFPSummary = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_RFP_SUMMARY.value
-    $script:blobContainerForRFPRisk = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_RFP_RISK.value
-    $script:blobContainerForRFPCompliance = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_RFP_COMPLIANCE.value
-    $script:blobContainerForContractSummary = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_CONTRACT_SUMMARY.value
-    $script:blobContainerForContractRisk = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_CONTRACT_RISK.value
-    $script:blobContainerForContractCompliance = $deploymentOutputs.azurE_STORAGE_CONTAINER_NAME_CONTRACT_COMPLIANCE.value
-    $script:aiSearchIndexForRetailCustomer = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_RETAIL_CUSTOMER.value
-    $script:aiSearchIndexForRetailOrder = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_RETAIL_ORDER.value
-    $script:aiSearchIndexForRFPSummary = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_RFP_SUMMARY.value
-    $script:aiSearchIndexForRFPRisk = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_RFP_RISK.value
-    $script:aiSearchIndexForRFPCompliance = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_RFP_COMPLIANCE.value
-    $script:aiSearchIndexForContractSummary = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_CONTRACT_SUMMARY.value
-    $script:aiSearchIndexForContractRisk = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_CONTRACT_RISK.value
-    $script:aiSearchIndexForContractCompliance = $deploymentOutputs.azurE_AI_SEARCH_INDEX_NAME_CONTRACT_COMPLIANCE.value
-    $script:aiSearch = $deploymentOutputs.azurE_AI_SEARCH_NAME.value
-    $script:backendUrl = $deploymentOutputs.backenD_URL.value
+    # Extract specific outputs with fallback logic
+    $script:storageAccount = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_ACCOUNT_NAME" -FallbackKey "azureStorageAccountName"
+    $script:blobContainerForRetailCustomer = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_RETAIL_CUSTOMER" -FallbackKey "azureStorageContainerNameRetailCustomer"
+    $script:blobContainerForRetailOrder = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_RETAIL_ORDER" -FallbackKey "azureStorageContainerNameRetailOrder"
+    $script:blobContainerForRFPSummary = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_RFP_SUMMARY" -FallbackKey "azureStorageContainerNameRfpSummary"
+    $script:blobContainerForRFPRisk = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_RFP_RISK" -FallbackKey "azureStorageContainerNameRfpRisk"
+    $script:blobContainerForRFPCompliance = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_RFP_COMPLIANCE" -FallbackKey "azureStorageContainerNameRfpCompliance"
+    $script:blobContainerForContractSummary = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_CONTRACT_SUMMARY" -FallbackKey "azureStorageContainerNameContractSummary"
+    $script:blobContainerForContractRisk = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_CONTRACT_RISK" -FallbackKey "azureStorageContainerNameContractRisk"
+    $script:blobContainerForContractCompliance = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_CONTAINER_NAME_CONTRACT_COMPLIANCE" -FallbackKey "azureStorageContainerNameContractCompliance"
+    $script:aiSearchIndexForRetailCustomer = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_RETAIL_CUSTOMER" -FallbackKey "azureAiSearchIndexNameRetailCustomer"
+    $script:aiSearchIndexForRetailOrder = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_RETAIL_ORDER" -FallbackKey "azureAiSearchIndexNameRetailOrder"
+    $script:aiSearchIndexForRFPSummary = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_RFP_SUMMARY" -FallbackKey "azureAiSearchIndexNameRfpSummary"
+    $script:aiSearchIndexForRFPRisk = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_RFP_RISK" -FallbackKey "azureAiSearchIndexNameRfpRisk"
+    $script:aiSearchIndexForRFPCompliance = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_RFP_COMPLIANCE" -FallbackKey "azureAiSearchIndexNameRfpCompliance"
+    $script:aiSearchIndexForContractSummary = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_CONTRACT_SUMMARY" -FallbackKey "azureAiSearchIndexNameContractSummary"
+    $script:aiSearchIndexForContractRisk = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_CONTRACT_RISK" -FallbackKey "azureAiSearchIndexNameContractRisk"
+    $script:aiSearchIndexForContractCompliance = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_INDEX_NAME_CONTRACT_COMPLIANCE" -FallbackKey "azureAiSearchIndexNameContractCompliance"
+    $script:aiSearch = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_NAME" -FallbackKey "azureAiSearchName"
+    $script:backendUrl = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "backenD_URL" -FallbackKey "backendUrl"
     
     # Validate that we extracted all required values
-    if (-not $script:storageAccount -or -not $script:blobContainer -or -not $script:aiSearch -or -not $script:aiSearchIndex -or -not $script:backendUrl) {
+    if (-not $script:storageAccount -or -not $script:aiSearch -or -not $script:backendUrl) {
         Write-Host "Error: Could not extract all required values from deployment outputs."
         return $false
     }

--- a/infra/scripts/selecting_team_config_and_data.sh
+++ b/infra/scripts/selecting_team_config_and_data.sh
@@ -86,6 +86,19 @@ function get_values_from_azd_env() {
     return 0
 }
 
+# Helper function to extract value with fallback
+extract_value() {
+    local primary_key="$1"
+    local fallback_key="$2"
+    local result
+    
+    result=$(echo "$deploymentOutputs" | grep -A 3 "\"$primary_key\"" | grep '"value"' | sed 's/.*"value": *"\([^"]*\)".*/\1/')
+    if [ -z "$result" ]; then
+        result=$(echo "$deploymentOutputs" | grep -A 3 "\"$fallback_key\"" | grep '"value"' | sed 's/.*"value": *"\([^"]*\)".*/\1/')
+    fi
+    echo "$result"
+}
+
 function get_values_from_az_deployment() {
     echo "Getting values from Azure deployment outputs..."
     
@@ -105,26 +118,26 @@ function get_values_from_az_deployment() {
         return 1
     fi
     
-    # Extract specific outputs using jq
-    storageAccount=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_ACCOUNT_NAME.value')
-    blobContainerForRetailCustomer=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_RETAIL_CUSTOMER.value')
-    blobContainerForRetailOrder=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_RETAIL_ORDER.value')
-    blobContainerForRFPSummary=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_RFP_SUMMARY.value')
-    blobContainerForRFPRisk=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_RFP_RISK.value')
-    blobContainerForRFPCompliance=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_RFP_COMPLIANCE.value')
-    blobContainerForContractSummary=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_CONTRACT_SUMMARY.value')
-    blobContainerForContractRisk=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_CONTRACT_RISK.value')
-    blobContainerForContractCompliance=$(echo "$deploymentOutputs" | jq -r '.azurE_STORAGE_CONTAINER_NAME_CONTRACT_COMPLIANCE.value')
-    aiSearchIndexForRetailCustomer=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_RETAIL_CUSTOMER.value')
-    aiSearchIndexForRetailOrder=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_RETAIL_ORDER.value')
-    aiSearchIndexForRFPSummary=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_RFP_SUMMARY.value')
-    aiSearchIndexForRFPRisk=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_RFP_RISK.value')
-    aiSearchIndexForRFPCompliance=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_RFP_COMPLIANCE.value')
-    aiSearchIndexForContractSummary=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_CONTRACT_SUMMARY.value')
-    aiSearchIndexForContractRisk=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_CONTRACT_RISK.value')
-    aiSearchIndexForContractCompliance=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_INDEX_NAME_CONTRACT_COMPLIANCE.value')
-    aiSearch=$(echo "$deploymentOutputs" | jq -r '.azurE_AI_SEARCH_NAME.value')
-    backendUrl=$(echo "$deploymentOutputs" | jq -r '.backenD_URL.value')
+    # Extract all values using the helper function
+    storageAccount=$(extract_value "azurE_STORAGE_ACCOUNT_NAME" "azureStorageAccountName")
+    blobContainerForRetailCustomer=$(extract_value "azurE_STORAGE_CONTAINER_NAME_RETAIL_CUSTOMER" "azureStorageContainerNameRetailCustomer")
+    blobContainerForRetailOrder=$(extract_value "azurE_STORAGE_CONTAINER_NAME_RETAIL_ORDER" "azureStorageContainerNameRetailOrder")
+    blobContainerForRFPSummary=$(extract_value "azurE_STORAGE_CONTAINER_NAME_RFP_SUMMARY" "azureStorageContainerNameRfpSummary")
+    blobContainerForRFPRisk=$(extract_value "azurE_STORAGE_CONTAINER_NAME_RFP_RISK" "azureStorageContainerNameRfpRisk")
+    blobContainerForRFPCompliance=$(extract_value "azurE_STORAGE_CONTAINER_NAME_RFP_COMPLIANCE" "azureStorageContainerNameRfpCompliance")
+    blobContainerForContractSummary=$(extract_value "azurE_STORAGE_CONTAINER_NAME_CONTRACT_SUMMARY" "azureStorageContainerNameContractSummary")
+    blobContainerForContractRisk=$(extract_value "azurE_STORAGE_CONTAINER_NAME_CONTRACT_RISK" "azureStorageContainerNameContractRisk")
+    blobContainerForContractCompliance=$(extract_value "azurE_STORAGE_CONTAINER_NAME_CONTRACT_COMPLIANCE" "azureStorageContainerNameContractCompliance")
+    aiSearchIndexForRetailCustomer=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_RETAIL_CUSTOMER" "azureAiSearchIndexNameRetailCustomer")
+    aiSearchIndexForRetailOrder=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_RETAIL_ORDER" "azureAiSearchIndexNameRetailOrder")
+    aiSearchIndexForRFPSummary=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_RFP_SUMMARY" "azureAiSearchIndexNameRfpSummary")
+    aiSearchIndexForRFPRisk=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_RFP_RISK" "azureAiSearchIndexNameRfpRisk")
+    aiSearchIndexForRFPCompliance=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_RFP_COMPLIANCE" "azureAiSearchIndexNameRfpCompliance")
+    aiSearchIndexForContractSummary=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_CONTRACT_SUMMARY" "azureAiSearchIndexNameContractSummary")
+    aiSearchIndexForContractRisk=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_CONTRACT_RISK" "azureAiSearchIndexNameContractRisk")
+    aiSearchIndexForContractCompliance=$(extract_value "azurE_AI_SEARCH_INDEX_NAME_CONTRACT_COMPLIANCE" "azureAiSearchIndexNameContractCompliance")
+    aiSearch=$(extract_value "azurE_AI_SEARCH_NAME" "azureAiSearchName")
+    backendUrl=$(extract_value "backenD_URL" "backendUrl")
     
     # Validate that we extracted all required values
     if [[ -z "$storageAccount" || -z "$aiSearch" || -z "$backendUrl" ]]; then


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request improves the robustness and flexibility of the post-deployment automation scripts by introducing fallback logic for extracting deployment output values. This ensures compatibility with varying output key names in Azure deployments. Additionally, the documentation is updated to reflect the new script names and usage.

**Enhancements to deployment scripts:**

* Added a helper function `Get-DeploymentValue` to `Selecting-Team-Config-And-Data.ps1` that attempts to retrieve deployment output values using a primary key and falls back to an alternative key if the primary is not present. All relevant output variable assignments in `Get-ValuesFromAzDeployment` now use this function, improving compatibility with different deployment output formats. [[1]](diffhunk://#diff-ad80b9b7270514b8f1e0f51923ef75c48a302267bf0af69703ef19d247a147c1R79-R100) [[2]](diffhunk://#diff-ad80b9b7270514b8f1e0f51923ef75c48a302267bf0af69703ef19d247a147c1L98-R142)
* Added a similar helper function `extract_value` to `selecting_team_config_and_data.sh` and updated all output variable assignments in `get_values_from_az_deployment` to use this function, providing the same fallback logic in the Bash script. [[1]](diffhunk://#diff-327759d0c2eeaa1e225978242dc160824111fc2dc514d3946e9b02fd1bef7f3cR89-R101) [[2]](diffhunk://#diff-327759d0c2eeaa1e225978242dc160824111fc2dc514d3946e9b02fd1bef7f3cL108-R140)

**Documentation updates:**

* Updated `AVMPostDeploymentGuide.md` to reference the new script names (`Selecting-Team-Config-And-Data.ps1` and `selecting_team_config_and_data.sh`) and their updated usage, ensuring that users follow the correct procedures post-deployment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->