### PR TITLE
fix: updated the team name

### DIFF
--- a/src/frontend/src/components/content/HomeInput.tsx
+++ b/src/frontend/src/components/content/HomeInput.tsx
@@ -73,7 +73,7 @@ const HomeInput: React.FC<HomeInputProps> = ({ selectedTeam }) => {
   // Check if the selected team is the Contract Compliance Review Team
   const isLegalTeam = selectedTeam?.name
     ?.toLowerCase()
-    .includes("ontract compliance");
+    .includes("contract compliance");
 
   useEffect(() => {
     if (location.state?.focusInput) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates the logic for identifying the Contract Compliance Review Team in the `HomeInput` component. The change corrects the string used to check if the selected team is the Contract Compliance Review Team.

Team identification logic update:

* In `HomeInput.tsx`, the substring used to determine if the selected team is the Contract Compliance Review Team was changed from `"compliance contract"` to `"contract compliance"`, ensuring the check matches the actual team name.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->