### PR TITLE
fix: Resolve RAI reuse bug (28329)

### DIFF
--- a/src/backend/v4/magentic_agents/common/lifecycle.py
+++ b/src/backend/v4/magentic_agents/common/lifecycle.py
@@ -153,10 +153,10 @@ class MCPEnabledBase:
 
     async def resolve_agent_id(self, agent_id: str) -> Optional[str]:
         """Resolve agent ID via Projects SDK first (for RAI agents), fallback to AgentsClient.
-        
+
         Args:
             agent_id: The agent ID to resolve
-            
+
         Returns:
             The resolved agent ID if found, None otherwise
         """
@@ -284,7 +284,7 @@ class MCPEnabledBase:
                     "RAI reuse: id unchanged (id=%s); skip save.", self._agent.id
                 )
                 return
-            
+
             currentAgent = CurrentTeamAgent(
                 team_id=self.team_config.team_id,
                 team_name=self.team_config.name,

--- a/src/backend/v4/magentic_agents/foundry_agent.py
+++ b/src/backend/v4/magentic_agents/foundry_agent.py
@@ -43,7 +43,7 @@ class FoundryAgentTemplate(AzureAgentBase):
     ) -> None:
         # Get project_client before calling super().__init__
         project_client = config.get_ai_project_client()
-        
+
         super().__init__(
             mcp=mcp_config,
             model_deployment_name=model_deployment_name,


### PR DESCRIPTION
## Purpose
This pull request improves the agent lifecycle management by introducing a more robust mechanism for resolving and saving agent IDs, especially for RAI agents, and refactors how `project_client` is handled in both the lifecycle and foundry agent classes. The changes ensure that agent reuse is more reliable, agent IDs are resolved using the correct client, and database operations avoid unnecessary writes.

### Agent ID resolution and reuse improvements

* Added the `resolve_agent_id` async method to prefer resolving agent IDs via the Projects SDK (`project_client`) before falling back to the legacy `AgentsClient`, improving reliability for RAI agents.
* Refactored `get_database_team_agent` to use the new `resolve_agent_id` method, log more informative messages, and prefer `project_client` for RAI agents when creating clients.

### Agent persistence logic

* Updated `save_database_team_agent` to skip saving if the agent ID hasn't changed, reducing unnecessary database writes and improving logging for agent reuse scenarios.

### Refactoring and consistency

* Passed `project_client` through constructors in both `lifecycle.py` and `foundry_agent.py`, ensuring consistent initialization and removing duplicate assignment. [[1]](diffhunk://#diff-ebae6c2c1a88357136b81af076389b635ae60419d01997f8de6fa4650ac49d39R46) [[2]](diffhunk://#diff-ebae6c2c1a88357136b81af076389b635ae60419d01997f8de6fa4650ac49d39R342) [[3]](diffhunk://#diff-ebae6c2c1a88357136b81af076389b635ae60419d01997f8de6fa4650ac49d39R354) [[4]](diffhunk://#diff-f49f3a1a3ad34fcb055e395a9054de7c7b7a925360c4144b34c8b2a34a184d22R44-R46) [[5]](diffhunk://#diff-f49f3a1a3ad34fcb055e395a9054de7c7b7a925360c4144b34c8b2a34a184d22R57-L59)
* Removed redundant assignment of `project_client` in `foundry_agent.py` after super constructor call, centralizing client setup.

### Invocation and agent saving

* Changed agent invocation logic so that the agent is saved to the database after each successful stream update, ensuring the latest agent state is persisted only when necessary.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->