### PR TITLE
fix: disable delete button for Contract Compliance Review Team

### DIFF
--- a/src/frontend/src/components/common/TeamSelector.tsx
+++ b/src/frontend/src/components/common/TeamSelector.tsx
@@ -70,8 +70,8 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
   const [uploadSuccessMessage, setUploadSuccessMessage] = useState<string | null>(null);
   // Helper function to check if a team is a default team
   const isDefaultTeam = (team: TeamConfig): boolean => {
-    const defaultTeamIds = ['team-1', 'team-2', 'team-3','team-clm-1'];
-    const defaultTeamNames = ['Human Resources Team', 'Product Marketing Team', 'Retail Customer Success Team','RFP Team'];
+    const defaultTeamIds = ['team-1', 'team-2', 'team-3','team-clm-1', 'team-compliance-1'];
+    const defaultTeamNames = ['Human Resources Team', 'Product Marketing Team', 'Retail Customer Success Team','RFP Team', 'Contract Compliance Review Team'];
     
     return defaultTeamIds.includes(team.team_id) || 
            defaultTeamNames.includes(team.name);


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the logic that determines default teams in the `TeamSelector` component. Specifically, it adds the "Contract Compliance Review Team" and its ID to the list of recognized default teams.

- Added `'team-compliance-1'` and `'Contract Compliance Review Team'` to the arrays used to identify default teams in `TeamSelector.tsx`.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->