### PR TITLE
fix: Added a fallback to post-deployment scripts to derive resource values from solution-suffix naming when deployment outputs are missing

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -241,6 +241,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
       Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
       DeploymentName: deployment().name
+      SolutionSuffix: solutionSuffix
     }
   }
 }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -239,6 +239,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
       Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
       DeploymentName: deployment().name
+      SolutionSuffix: solutionSuffix
     }
   }
 }

--- a/infra/scripts/Selecting-Team-Config-And-Data.ps1
+++ b/infra/scripts/Selecting-Team-Config-And-Data.ps1
@@ -148,6 +148,70 @@ function Get-ValuesFromAzDeployment {
     return $true
 }
 
+function Get-ValuesUsingSolutionSuffix {
+    Write-Host "Getting values from resource naming convention using solution suffix..."
+    
+    # Get the solution suffix from resource group tags
+    $solutionSuffix = az group show --name $ResourceGroup --query "tags.SolutionSuffix" -o tsv
+    if (-not $solutionSuffix) {
+        Write-Host "Error: Could not find SolutionSuffix tag in resource group."
+        return $false
+    }
+    
+    Write-Host "Found solution suffix: $solutionSuffix"
+    
+    # Reconstruct resource names using same naming convention as Bicep
+    $script:storageAccount = "st$solutionSuffix" -replace '-', ''  # Remove dashes like Bicep does
+    $script:aiSearch = "srch-$solutionSuffix"
+    $containerAppName = "ca-$solutionSuffix"
+    
+    # Query dynamic value (backend URL) from Container App
+    Write-Host "Querying backend URL from Container App..."
+    $backendFqdn = az containerapp show `
+      --name $containerAppName `
+      --resource-group $ResourceGroup `
+      --query "properties.configuration.ingress.fqdn" `
+      -o tsv 2>$null
+    
+    if (-not $backendFqdn) {
+        Write-Host "Error: Could not get Container App FQDN. Container App may not be deployed yet."
+        return $false
+    }
+    
+    $script:backendUrl = "https://$backendFqdn"
+    
+    # Hardcoded container names (These don't follow the suffix pattern in Bicep, hence need to be changed here if changed in Bicep)
+    $script:blobContainerForRetailCustomer = "retail-dataset-customer"
+    $script:blobContainerForRetailOrder = "retail-dataset-order"
+    $script:blobContainerForRFPSummary = "rfp-summary-dataset"
+    $script:blobContainerForRFPRisk = "rfp-risk-dataset"
+    $script:blobContainerForRFPCompliance = "rfp-compliance-dataset"
+    $script:blobContainerForContractSummary = "contract-summary-dataset"
+    $script:blobContainerForContractRisk = "contract-risk-dataset"
+    $script:blobContainerForContractCompliance = "contract-compliance-dataset"
+    
+    # Hardcoded index names (These don't follow the suffix pattern in Bicep, hence need to be changed here if changed in Bicep)
+    $script:aiSearchIndexForRetailCustomer = "macae-retail-customer-index"
+    $script:aiSearchIndexForRetailOrder = "macae-retail-order-index"
+    $script:aiSearchIndexForRFPSummary = "macae-rfp-summary-index"
+    $script:aiSearchIndexForRFPRisk = "macae-rfp-risk-index"
+    $script:aiSearchIndexForRFPCompliance = "macae-rfp-compliance-index"
+    $script:aiSearchIndexForContractSummary = "contract-summary-doc-index"
+    $script:aiSearchIndexForContractRisk = "contract-risk-doc-index"
+    $script:aiSearchIndexForContractCompliance = "contract-compliance-doc-index"
+    
+    $script:directoryPath = "data/agent_teams"
+    
+    # Validate that we got all critical values
+    if (-not $script:storageAccount -or -not $script:aiSearch -or -not $script:backendUrl) {
+        Write-Host "Error: Failed to reconstruct all required resource names."
+        return $false
+    }
+    
+    Write-Host "Successfully reconstructed values from resource naming convention."
+    return $true
+}
+
 # Authenticate with Azure
 try {
     $null = az account show 2>$null
@@ -233,12 +297,23 @@ if (-not $ResourceGroup) {
         exit 1
     }
 } else {
-    # Resource group provided - use deployment outputs
+    # Resource group provided - try deployment outputs first, then fallback to naming convention
     Write-Host "Resource group provided: $ResourceGroup"
     
     if (-not (Get-ValuesFromAzDeployment)) {
-        Write-Host "Failed to get values from deployment outputs."
-        exit 1
+        Write-Host ""
+        Write-Host "Warning: Could not retrieve values from deployment outputs (deployment may be deleted)."
+        Write-Host "Attempting fallback method: reconstructing values from resource naming convention..."
+        Write-Host ""
+        
+        if (-not (Get-ValuesUsingSolutionSuffix)) {
+            Write-Host ""
+            Write-Host "Error: Both methods failed to retrieve configuration values."
+            Write-Host "Please ensure:"
+            Write-Host "  1. The deployment exists and has a DeploymentName tag, OR"
+            Write-Host "  2. The resource group has a SolutionSuffix tag"
+            exit 1
+        }
     }
 }
 

--- a/infra/scripts/Selecting-Team-Config-And-Data.ps1
+++ b/infra/scripts/Selecting-Team-Config-And-Data.ps1
@@ -505,6 +505,7 @@ if($useCaseSelection -eq "1"-or $useCaseSelection -eq "2" -or $useCaseSelection 
             $stIsPublicAccessDisabled = $true
             Write-Host "Enabling public access for storage account: $storageAccount"
             az storage account update --name $storageAccount --public-network-access enabled --default-action Allow --output none
+            Start-Sleep -Seconds 60
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Error: Failed to enable public access for storage account."
                 exit 1
@@ -519,6 +520,7 @@ if($useCaseSelection -eq "1"-or $useCaseSelection -eq "2" -or $useCaseSelection 
             $srchIsPublicAccessDisabled = $true
             Write-Host "Enabling public access for search service: $aiSearch"
             az search service update --name $aiSearch --resource-group $ResourceGroup --public-network-access enabled --output none
+            Start-Sleep -Seconds 60
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Error: Failed to enable public access for search service."
                 exit 1

--- a/infra/scripts/Selecting-Team-Config-And-Data.ps1
+++ b/infra/scripts/Selecting-Team-Config-And-Data.ps1
@@ -505,11 +505,11 @@ if($useCaseSelection -eq "1"-or $useCaseSelection -eq "2" -or $useCaseSelection 
             $stIsPublicAccessDisabled = $true
             Write-Host "Enabling public access for storage account: $storageAccount"
             az storage account update --name $storageAccount --public-network-access enabled --default-action Allow --output none
-            Start-Sleep -Seconds 60
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Error: Failed to enable public access for storage account."
                 exit 1
             }
+            Start-Sleep -Seconds 60
         }
         else {
             Write-Host "Public access is already enabled for storage account: $storageAccount"
@@ -520,11 +520,11 @@ if($useCaseSelection -eq "1"-or $useCaseSelection -eq "2" -or $useCaseSelection 
             $srchIsPublicAccessDisabled = $true
             Write-Host "Enabling public access for search service: $aiSearch"
             az search service update --name $aiSearch --resource-group $ResourceGroup --public-network-access enabled --output none
-            Start-Sleep -Seconds 60
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "Error: Failed to enable public access for search service."
                 exit 1
             }
+            Start-Sleep -Seconds 60
         }
         else {
             Write-Host "Public access is already enabled for search service: $AiSearch"

--- a/infra/scripts/selecting_team_config_and_data.sh
+++ b/infra/scripts/selecting_team_config_and_data.sh
@@ -480,11 +480,11 @@ if [[ "$useCaseSelection" == "1" || "$useCaseSelection" == "2" || "$useCaseSelec
             stIsPublicAccessDisabled=true
             echo "Enabling public access for storage account: $storageAccount"
             az storage account update --name "$storageAccount" --public-network-access enabled --default-action Allow --output none
-            sleep 60
             if [[ $? -ne 0 ]]; then
                 echo "Error: Failed to enable public access for storage account."
                 exit 1
             fi
+            sleep 60
         else
             echo "Public access is already enabled for storage account: $storageAccount"
         fi
@@ -494,11 +494,11 @@ if [[ "$useCaseSelection" == "1" || "$useCaseSelection" == "2" || "$useCaseSelec
             srchIsPublicAccessDisabled=true
             echo "Enabling public access for search service: $aiSearch"
             az search service update --name "$aiSearch" --resource-group "$ResourceGroup" --public-network-access enabled --output none
-            sleep 60
             if [[ $? -ne 0 ]]; then
                 echo "Error: Failed to enable public access for search service."
                 exit 1
             fi
+            sleep 60
         else
             echo "Public access is already enabled for search service: $aiSearch"
         fi

--- a/infra/scripts/selecting_team_config_and_data.sh
+++ b/infra/scripts/selecting_team_config_and_data.sh
@@ -480,6 +480,7 @@ if [[ "$useCaseSelection" == "1" || "$useCaseSelection" == "2" || "$useCaseSelec
             stIsPublicAccessDisabled=true
             echo "Enabling public access for storage account: $storageAccount"
             az storage account update --name "$storageAccount" --public-network-access enabled --default-action Allow --output none
+            sleep 60
             if [[ $? -ne 0 ]]; then
                 echo "Error: Failed to enable public access for storage account."
                 exit 1
@@ -493,6 +494,7 @@ if [[ "$useCaseSelection" == "1" || "$useCaseSelection" == "2" || "$useCaseSelec
             srchIsPublicAccessDisabled=true
             echo "Enabling public access for search service: $aiSearch"
             az search service update --name "$aiSearch" --resource-group "$ResourceGroup" --public-network-access enabled --output none
+            sleep 60
             if [[ $? -ne 0 ]]; then
                 echo "Error: Failed to enable public access for search service."
                 exit 1


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request enhances the robustness of the infrastructure deployment scripts by introducing a fallback mechanism for retrieving resource configuration values using the `SolutionSuffix` tag when deployment outputs are unavailable. It also adds short delays after enabling public access for certain Azure resources to ensure changes propagate correctly. The most important changes are:

**Fallback Logic for Resource Configuration Retrieval:**
- Added new functions (`Get-ValuesUsingSolutionSuffix` in PowerShell and `get_values_using_solution_suffix` in Bash) to reconstruct resource names and critical values from the `SolutionSuffix` tag in the resource group, improving reliability when deployment outputs are missing. [[1]](diffhunk://#diff-ad80b9b7270514b8f1e0f51923ef75c48a302267bf0af69703ef19d247a147c1R151-R214) [[2]](diffhunk://#diff-327759d0c2eeaa1e225978242dc160824111fc2dc514d3946e9b02fd1bef7f3cR152-R215)
- Updated scripts to attempt retrieval from deployment outputs first, then fall back to the naming convention using `SolutionSuffix`, with user-friendly error messages and guidance if both methods fail. [[1]](diffhunk://#diff-ad80b9b7270514b8f1e0f51923ef75c48a302267bf0af69703ef19d247a147c1L236-R318) [[2]](diffhunk://#diff-327759d0c2eeaa1e225978242dc160824111fc2dc514d3946e9b02fd1bef7f3cL234-R316)

**Infrastructure Tagging:**
- Modified Bicep templates (`main.bicep` and `main_custom.bicep`) to include the `SolutionSuffix` tag in resource group tags, enabling the fallback mechanism. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R244) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62R242)

**Operational Reliability Improvements:**
- Added a 60-second delay after enabling public access for storage accounts and search services in both PowerShell and Bash scripts to allow time for the changes to take effect, reducing the likelihood of race conditions. [[1]](diffhunk://#diff-ad80b9b7270514b8f1e0f51923ef75c48a302267bf0af69703ef19d247a147c1R508) [[2]](diffhunk://#diff-ad80b9b7270514b8f1e0f51923ef75c48a302267bf0af69703ef19d247a147c1R523) [[3]](diffhunk://#diff-327759d0c2eeaa1e225978242dc160824111fc2dc514d3946e9b02fd1bef7f3cR483) [[4]](diffhunk://#diff-327759d0c2eeaa1e225978242dc160824111fc2dc514d3946e9b02fd1bef7f3cR497)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->