### PR TITLE
fix: updated the condition to check bash terminal from windows machine

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,20 +8,40 @@ hooks:
   postdeploy:
     windows:
       run: |
-        Write-Host ""
-        Write-Host "===============================================================" -ForegroundColor Yellow
-        Write-Host " POST-DEPLOYMENT STEP (PowerShell) " -ForegroundColor Green
-        Write-Host "===============================================================" -ForegroundColor Yellow
-        Write-Host ""
+        # Detect if running in Git Bash or similar Bash environment
+        if ($env:SHELL -like "*bash*" -or $env:MSYSTEM) {
+          # Running in Git Bash/MSYS2 environment
+          Write-Host ""
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host " POST-DEPLOYMENT STEPS (Bash)" -ForegroundColor Green  
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host ""
 
-        Write-Host " Upload Team Configurations and index sample data" -ForegroundColor White
-        Write-Host "  👉 Run the following command in PowerShell:" -ForegroundColor White
-        Write-Host "   infra\scripts\Selecting-Team-Config-And-Data.ps1" -ForegroundColor Cyan
-        Write-Host ""
+          Write-Host " Upload Team Configurations and index sample data" -ForegroundColor White
+          Write-Host "  👉 Run the following command in Bash:" -ForegroundColor White
+          Write-Host "   bash infra/scripts/selecting_team_config_and_data.sh" -ForegroundColor Cyan
+          Write-Host ""
 
-        Write-Host "🌐 Access your deployed Frontend application at:" -ForegroundColor Green
-        Write-Host "   https://$env:webSiteDefaultHostname" -ForegroundColor Cyan
-        Write-Host ""
+          Write-Host "🌐 Access your deployed Frontend application at:" -ForegroundColor Green
+          Write-Host "   https://$env:webSiteDefaultHostname" -ForegroundColor Cyan
+          Write-Host ""
+        } else {
+          # Running in PowerShell
+          Write-Host ""
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host " POST-DEPLOYMENT STEP (PowerShell) " -ForegroundColor Green
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host ""
+
+          Write-Host " Upload Team Configurations and index sample data" -ForegroundColor White
+          Write-Host "  👉 Run the following command in PowerShell:" -ForegroundColor White
+          Write-Host "   infra\scripts\Selecting-Team-Config-And-Data.ps1" -ForegroundColor Cyan
+          Write-Host ""
+
+          Write-Host "🌐 Access your deployed Frontend application at:" -ForegroundColor Green
+          Write-Host "   https://$env:webSiteDefaultHostname" -ForegroundColor Cyan
+          Write-Host ""
+        }
         
       shell: pwsh
       interactive: true

--- a/azure_custom.yaml
+++ b/azure_custom.yaml
@@ -47,20 +47,40 @@ hooks:
   postdeploy:
     windows:
       run: |
-        Write-Host ""
-        Write-Host "===============================================================" -ForegroundColor Yellow
-        Write-Host " POST-DEPLOYMENT STEP (PowerShell) " -ForegroundColor Green
-        Write-Host "===============================================================" -ForegroundColor Yellow
-        Write-Host ""
+        # Detect if running in Git Bash or similar Bash environment
+        if ($env:SHELL -like "*bash*" -or $env:MSYSTEM) {
+          # Running in Git Bash/MSYS2 environment
+          Write-Host ""
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host " POST-DEPLOYMENT STEPS (Bash)" -ForegroundColor Green  
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host ""
 
-        Write-Host " Upload Team Configurations and index sample data" -ForegroundColor White
-        Write-Host "  👉 Run the following command in PowerShell:" -ForegroundColor White
-        Write-Host "   infra\scripts\Selecting-Team-Config-And-Data.ps1" -ForegroundColor Cyan
-        Write-Host ""
+          Write-Host " Upload Team Configurations and index sample data" -ForegroundColor White
+          Write-Host "  👉 Run the following command in Bash:" -ForegroundColor White
+          Write-Host "   bash infra/scripts/selecting_team_config_and_data.sh" -ForegroundColor Cyan
+          Write-Host ""
 
-        Write-Host "🌐 Access your deployed Frontend application at:" -ForegroundColor Green
-        Write-Host "   https://$env:webSiteDefaultHostname" -ForegroundColor Cyan
-        Write-Host ""
+          Write-Host "🌐 Access your deployed Frontend application at:" -ForegroundColor Green
+          Write-Host "   https://$env:webSiteDefaultHostname" -ForegroundColor Cyan
+          Write-Host ""
+        } else {
+          # Running in PowerShell
+          Write-Host ""
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host " POST-DEPLOYMENT STEP (PowerShell) " -ForegroundColor Green
+          Write-Host "===============================================================" -ForegroundColor Yellow
+          Write-Host ""
+
+          Write-Host " Upload Team Configurations and index sample data" -ForegroundColor White
+          Write-Host "  👉 Run the following command in PowerShell:" -ForegroundColor White
+          Write-Host "   infra\scripts\Selecting-Team-Config-And-Data.ps1" -ForegroundColor Cyan
+          Write-Host ""
+
+          Write-Host "🌐 Access your deployed Frontend application at:" -ForegroundColor Green
+          Write-Host "   https://$env:webSiteDefaultHostname" -ForegroundColor Cyan
+          Write-Host ""
+        }
         
       shell: pwsh
       interactive: true


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request improves the post-deployment experience for Windows users by making the deployment scripts in both `azure.yaml` and `azure_custom.yaml` detect whether they are running in a Bash-like environment (such as Git Bash/MSYS2) or in PowerShell. Based on the detected shell, the scripts now display tailored instructions and commands for uploading team configurations and accessing the deployed frontend application.

Shell detection and tailored instructions:

* Added logic to both `azure.yaml` and `azure_custom.yaml` to detect if the post-deployment script is running in a Bash environment (`$env:SHELL` or `$env:MSYSTEM`) or PowerShell, and show corresponding instructions. [[1]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R11-R29) [[2]](diffhunk://#diff-09dca1f3eeb0d08b888401e046f12ffe5293e76db9fca18dfbc4b6a9f5a5fae3R50-R68)
* For Bash environments, the script now displays a specific command (`bash infra/scripts/selecting_team_config_and_data.sh`) for uploading team configurations and indexing sample data, along with clear formatting and color-coded output. [[1]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R11-R29) [[2]](diffhunk://#diff-09dca1f3eeb0d08b888401e046f12ffe5293e76db9fca18dfbc4b6a9f5a5fae3R50-R68)
* For PowerShell environments, the script continues to show the existing PowerShell instructions, ensuring users get the right guidance for their shell. [[1]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R11-R29) [[2]](diffhunk://#diff-09dca1f3eeb0d08b888401e046f12ffe5293e76db9fca18dfbc4b6a9f5a5fae3R50-R68)
* The changes ensure the correct closing of the conditional blocks for both Bash and PowerShell instructions in the deployment scripts. [[1]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R44) [[2]](diffhunk://#diff-09dca1f3eeb0d08b888401e046f12ffe5293e76db9fca18dfbc4b6a9f5a5fae3R83)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->