### PR TITLE
fix: Dev v4 to main merge

### DIFF
--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -300,6 +300,10 @@ azd auth login --tenant-id <tenant-id>
 3. Under the **Overview** section, locate the **Tenant ID** field. Copy the value displayed
 
 ### 4.2 Start Deployment
+**NOTE:** If you are running the latest azd version (version 1.23.9), please run the following command. 
+```bash 
+azd config set provision.preflight off
+```
 
 ```shell
 azd up

--- a/src/backend/v4/orchestration/human_approval_manager.py
+++ b/src/backend/v4/orchestration/human_approval_manager.py
@@ -221,6 +221,8 @@ DO NOT EVER OFFER TO HELP FURTHER IN THE FINAL ANSWER! Just provide the final an
     async def create_progress_ledger(self, magentic_context: MagenticContext):
         """
         Check for max rounds exceeded and send final message if so, else defer to base.
+        After base evaluation, prevent premature satisfaction by ensuring all planned
+        agents have responded before allowing is_request_satisfied=True.
 
         Returns:
             Progress ledger object (type depends on agent_framework version)
@@ -256,7 +258,65 @@ DO NOT EVER OFFER TO HELP FURTHER IN THE FINAL ANSWER! Just provide the final an
             return ledger
 
         # Delegate to base for normal progress ledger creation
-        return await super().create_progress_ledger(magentic_context)
+        ledger = await super().create_progress_ledger(magentic_context)
+
+        # --- Premature satisfaction guard ---
+        # If the LLM says the request is satisfied, verify that all planned
+        # (non-proxy, non-manager) agents have actually responded before allowing
+        # the workflow to terminate.  This addresses the bug where the orchestrator
+        # marks satisfied=True after a single comprehensive agent response.
+        if ledger.is_request_satisfied.answer:
+            uncalled = self._get_uncalled_agents(magentic_context)
+            if uncalled:
+                next_agent = uncalled[0]
+                logger.info(
+                    "Progress ledger marked satisfied but %d agent(s) have not responded yet: %s. "
+                    "Overriding to continue with '%s'.",
+                    len(uncalled),
+                    uncalled,
+                    next_agent,
+                )
+                ledger.is_request_satisfied.answer = False
+                ledger.is_request_satisfied.reason = (
+                    f"Not all agents have responded yet. Waiting for: {', '.join(uncalled)}"
+                )
+                ledger.is_progress_being_made.answer = True
+                ledger.is_progress_being_made.reason = "Continuing to consult remaining agents"
+                ledger.next_speaker.answer = next_agent
+                ledger.next_speaker.reason = f"{next_agent} has not yet been consulted"
+                # Always override instruction with task-relevant prompt so that
+                # data agents (Azure AI Search, RAG) execute meaningful queries
+                # instead of receiving a stale finalization instruction.
+                task_text = getattr(magentic_context.task, "text", str(magentic_context.task))
+                ledger.instruction_or_question.answer = (
+                    f"Using your available tools and data sources, provide your response for the following task: {task_text}"
+                )
+                ledger.instruction_or_question.reason = (
+                    f"Routing to {next_agent} who has not yet contributed"
+                )
+
+        return ledger
+
+    @staticmethod
+    def _get_uncalled_agents(magentic_context: MagenticContext) -> list[str]:
+        """Return agent names from participant_descriptions that have not yet
+        authored a message in the chat_history (excluding ProxyAgent and the
+        MagenticManager)."""
+        skip_names = {"ProxyAgent", "MagenticManager", "magentic_manager"}
+
+        all_agents = [
+            name for name in magentic_context.participant_descriptions
+            if name not in skip_names
+        ]
+
+        # Collect author names that appear in chat_history
+        responded = set()
+        for msg in magentic_context.chat_history:
+            author = getattr(msg, "author_name", None)
+            if author:
+                responded.add(author)
+
+        return [name for name in all_agents if name not in responded]
 
     async def _wait_for_user_approval(
         self, m_plan_id: Optional[str] = None

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -1,6 +1,8 @@
 """BIAB Page object for automating interactions with the Multi-Agent Planner UI."""
 
 import logging
+import os
+from datetime import datetime
 from playwright.sync_api import expect
 from base.base import BasePage
 
@@ -32,6 +34,7 @@ class BIABPage(BasePage):
     PROXY_AGENT = "//span[normalize-space()='Proxy Agent']"
     APPROVE_TASK_PLAN = "//button[normalize-space()='Approve Task Plan']"
     PROCESSING_PLAN = "//span[contains(text(),'Processing your plan and coordinating with AI agen')]"
+    AI_THINKING_PROCESS = "//span[normalize-space()='AI Thinking Process']"
     RETAIL_CUSTOMER_RESPONSE_VALIDATION = "//p[contains(text(),'🎉🎉')]"
     PRODUCT_MARKETING_RESPONSE_VALIDATION = "//p[contains(text(),'🎉🎉')]"
     RFP_RESPONSE_VALIDATION = "//p[contains(text(),'🎉🎉')]"
@@ -365,7 +368,7 @@ class BIABPage(BasePage):
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
         
-        logger.info("Task plan approval and processing completed successfully!")
+        logger.info("Retail task plan approval and processing completed successfully!")
 
     def approve_task_plan(self):
         """Approve the task plan and wait for processing to complete (without clarification check)."""
@@ -510,14 +513,50 @@ class BIABPage(BasePage):
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
         
         logger.info("Contract Compliance task plan approval and processing completed successfully!")
+
     def validate_retail_customer_response(self):
         """Validate the retail customer response."""
 
         logger.info("Validating retail customer response...")
-        expect(self.page.locator(self.RETAIL_CUSTOMER_RESPONSE_VALIDATION)).to_be_visible(timeout=10000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.RETAIL_CUSTOMER_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Retail customer response is visible")
-        expect(self.page.locator(self.RETAIL_COMPLETED_TASK).first).to_be_visible(timeout=6000)
-        logger.info("✓ Retail completed task is visible")
+        
+        # Validate retail response contains expected content
+        logger.info("Checking for retail customer analysis tasks...")
+        try:
+            # Look for common retail task content that appears in responses
+            retail_task_patterns = [
+                "//h5[contains(text(), 'Customer')]",
+                "//h5[contains(text(), 'Analysis')]",
+                "//h5[contains(text(), 'Satisfaction')]",
+                "//p[contains(text(), 'Emily Thompson')]",
+                "//p[contains(text(), 'Contoso')]"
+            ]
+            
+            task_found = False
+            for pattern in retail_task_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ Retail task validated with content pattern")
+                    task_found = True
+                    break
+            
+            if not task_found:
+                logger.warning("⚠ No specific retail task content found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ Retail task validation check failed, but main response is successful: {e}")
          
         # Soft assertions for Order Data, Customer Data, and Analysis Recommendation
         logger.info("Checking Order Data visibility...")
@@ -546,10 +585,45 @@ class BIABPage(BasePage):
         """Validate the product marketing response."""
 
         logger.info("Validating product marketing response...")
-        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Product marketing response is visible")
-        expect(self.page.locator(self.PM_COMPLETED_TASK).first).to_be_visible(timeout=6000)
-        logger.info("✓ Product marketing completed task is visible")
+        
+        # Validate product marketing response contains expected content
+        logger.info("Checking for product marketing tasks...")
+        try:
+            # Look for common product marketing task content that appears in responses
+            pm_task_patterns = [
+                "//h5[contains(text(), 'Press Release')]",
+                "//h5[contains(text(), 'Product')]",
+                "//h5[contains(text(), 'Marketing')]",
+                "//p[contains(text(), 'press release')]",
+                "//p[contains(text(), 'products')]"
+            ]
+            
+            task_found = False
+            for pattern in pm_task_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ Product marketing task validated with content pattern")
+                    task_found = True
+                    break
+            
+            if not task_found:
+                logger.warning("⚠ No specific product marketing task content found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ Product marketing task validation check failed, but main response is successful: {e}")
         
         # Soft assertions for Product and Marketing
         logger.info("Checking Product visibility...")
@@ -570,10 +644,47 @@ class BIABPage(BasePage):
         """Validate the HR response."""
 
         logger.info("Validating HR response...")
-        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        logger.info("Waiting for HR response validation (celebration emoji)...")
+        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ HR response is visible")
-        expect(self.page.locator(self.HR_COMPLETED_TASK).first).to_be_visible(timeout=6000)
-        logger.info("✓ HR completed task is visible")
+        
+        # Validate HR response contains expected onboarding tasks
+        logger.info("Checking for HR onboarding tasks completion...")
+        try:
+            # Look for common HR onboarding task headings that appear in responses
+            hr_task_patterns = [
+                "//h5[contains(text(), 'Orientation Session')]",
+                "//h5[contains(text(), 'Employee Handbook')]",
+                "//h5[contains(text(), 'Benefits Registration')]",
+                "//h5[contains(text(), 'Payroll Setup')]",
+                "//p[contains(text(), 'Jessica Smith')]",
+                "//p[contains(text(), 'successfully onboarded')]"
+            ]
+            
+            task_found = False
+            for pattern in hr_task_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ HR onboarding task validated with pattern: {pattern}")
+                    task_found = True
+                    break
+            
+            if not task_found:
+                logger.warning("⚠ No specific HR onboarding task headings found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ HR task validation check failed, but main response is successful: {e}")
         
         # Soft assertions for Technical Support and HR Helper
         logger.info("Checking Technical Support visibility...")
@@ -594,59 +705,91 @@ class BIABPage(BasePage):
         """Validate the RFP response."""
 
         logger.info("Validating RFP response...")
-        expect(self.page.locator(self.RFP_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.RFP_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ RFP response is visible")
         
-        # Soft assertions for RFP Summary, RFP Risk, and RFP Compliance
-        logger.info("Checking RFP Summary visibility...")
+        # Validate RFP response contains expected content
+        logger.info("Checking for RFP analysis content...")
         try:
-            expect(self.page.locator(self.RFP_SUMMARY).first).to_be_visible(timeout=10000)
-            logger.info("✓ RFP Summary is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ RFP Summary Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking RFP Risk visibility...")
-        try:
-            expect(self.page.locator(self.RFP_RISK).first).to_be_visible(timeout=10000)
-            logger.info("✓ RFP Risk is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ RFP Risk Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking RFP Compliance visibility...")
-        try:
-            expect(self.page.locator(self.RFP_COMPLIANCE).first).to_be_visible(timeout=10000)
-            logger.info("✓ RFP Compliance is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ RFP Compliance Agent is NOT Utilized in response: {e}")
+            # Look for common RFP response content patterns
+            rfp_content_patterns = [
+                "//p[contains(text(), 'RFP')]",
+                "//p[contains(text(), 'proposal')]",
+                "//p[contains(text(), 'Woodgrove Bank')]",
+                "//p[contains(text(), 'Contoso')]",
+                "//p[contains(text(), 'response')]",
+                "//p[contains(text(), 'project')]"
+            ]
+            
+            content_found = False
+            for pattern in rfp_content_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ RFP response content validated with pattern")
+                    content_found = True
+                    break
+            
+            if not content_found:
+                logger.warning("⚠ No specific RFP content patterns found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ RFP content validation check failed, but main response is successful: {e}")
 
     def validate_contract_compliance_response(self):
         """Validate the Contract Compliance response."""
 
         logger.info("Validating Contract Compliance response...")
-        expect(self.page.locator(self.CC_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.CC_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Contract Compliance response is visible")
         
-        # Soft assertions for Contract Summary, Contract Risk, and Contract Compliance
-        logger.info("Checking Contract Summary visibility...")
+        # Validate Contract Compliance response contains expected content
+        logger.info("Checking for Contract Compliance analysis content...")
         try:
-            expect(self.page.locator(self.CONTRACT_SUMMARY).first).to_be_visible(timeout=10000)
-            logger.info("✓ Contract Summary is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ Contract Summary Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking Contract Risk visibility...")
-        try:
-            expect(self.page.locator(self.CONTRACT_RISK).first).to_be_visible(timeout=10000)
-            logger.info("✓ Contract Risk is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ Contract Risk Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking Contract Compliance visibility...")
-        try:
-            expect(self.page.locator(self.CONTRACT_COMPLIANCE).first).to_be_visible(timeout=10000)
-            logger.info("✓ Contract Compliance is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ Contract Compliance Agent is NOT Utilized in response: {e}")
+            # Look for common contract compliance response content patterns
+            cc_content_patterns = [
+                "//p[contains(text(), 'contract')]",
+                "//p[contains(text(), 'compliance')]",
+                "//p[contains(text(), 'agreement')]",
+                "//p[contains(text(), 'terms')]",
+                "//p[contains(text(), 'review')]",
+                "//h5[contains(text(), 'Contract')]"
+            ]
+            
+            content_found = False
+            for pattern in cc_content_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ Contract Compliance response content validated with pattern")
+                    content_found = True
+                    break
+            
+            if not content_found:
+                logger.warning("⚠ No specific Contract Compliance content patterns found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ Contract Compliance content validation check failed, but main response is successful: {e}")
 
     def click_new_task(self):
         """Click on the New Task button."""
@@ -659,8 +802,14 @@ class BIABPage(BasePage):
         """Input clarification text and click send button."""
         logger.info("Starting clarification input process...")
         
+        # Wait for the clarification input to be enabled before typing
+        logger.info("Waiting for clarification input to be enabled...")
+        clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
+        expect(clarification_input).to_be_enabled(timeout=60000)
+        logger.info("✓ Clarification input is enabled")
+        
         logger.info(f"Typing clarification: {clarification_text}")
-        self.page.locator(self.INPUT_CLARIFICATION).fill(clarification_text)
+        clarification_input.fill(clarification_text)
         self.page.wait_for_timeout(1000)
         logger.info("✓ Clarification text entered")
         
@@ -671,13 +820,21 @@ class BIABPage(BasePage):
         
         logger.info("Clarification input and send completed successfully!")
 
+        # Try to wait for processing message, but if it's already gone (fast processing), that's okay
         logger.info("Waiting for 'Processing your plan' message to be visible...")
-        expect(self.page.locator(self.PROCESSING_PLAN)).to_be_visible(timeout=15000)
-        logger.info("✓ 'Processing your plan' message is visible")
-
-        logger.info("Waiting for plan processing to complete...")
-        self.page.locator(self.PROCESSING_PLAN).wait_for(state="hidden", timeout=200000)
-        logger.info("✓ Plan processing completed")
+        try:
+            expect(self.page.locator(self.PROCESSING_PLAN)).to_be_visible(timeout=10000)
+            logger.info("✓ 'Processing your plan' message is visible")
+            
+            logger.info("Waiting for plan processing to complete...")
+            self.page.locator(self.PROCESSING_PLAN).wait_for(state="hidden", timeout=200000)
+            logger.info("✓ Plan processing completed")
+        except Exception as e:
+            # Processing may have completed so quickly that the message was never detected
+            logger.info(f"Processing message not detected or already completed: {e}")
+            # Give a small buffer to ensure any processing is complete
+            self.page.wait_for_timeout(3000)
+            logger.info("✓ Proceeding - processing likely completed quickly")
 
     def input_rai_clarification_and_send(self, clarification_text):
         """Input RAI clarification text and click send button (for RAI testing)."""
@@ -716,16 +873,132 @@ class BIABPage(BasePage):
         logger.info("✓ Send button clicked")
 
     def validate_rai_error_message(self):
-        """Validate that the RAI 'Unable to create plan' error message is visible."""
-        logger.info("Validating RAI 'Unable to create plan' message is visible...")
-        expect(self.page.locator(self.UNABLE_TO_CREATE_PLAN)).to_be_visible(timeout=10000)
-        logger.info("✓ RAI 'Unable to create plan' message is visible")
+        """Validate that RAI blocked the prompt by checking for error messages."""
+        logger.info("Validating RAI error response...")
+        
+        # The flow: toast shows "Creating a plan" briefly, then updates to "Unable to create plan"
+        # First, wait for the "Creating a plan" message to appear (confirms request was sent)
+        try:
+            logger.info("Waiting for plan creation attempt to start...")
+            self.page.locator("//span[contains(text(), 'Creating a plan')]").wait_for(state="visible", timeout=10000)
+            logger.info("✓ Plan creation started")
+        except Exception as e:
+            logger.warning(f"'Creating a plan' message not detected: {e}")
+        
+        # Now wait for it to change to the error message
+        logger.info("Waiting for RAI error message to appear...")
+        
+        # Check for various possible error messages that indicate RAI blocking
+        possible_error_locators = [
+            "//span[normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and contains(text(), 'Unable to create plan')]",
+            self.UNABLE_TO_CREATE_PLAN,
+            "//span[contains(text(), 'Unable to create plan')]",
+            "//span[contains(text(), 'Unable')]",
+            "//span[contains(text(), 'Error')]",
+            "//span[contains(text(), 'failed')]",
+            "//div[contains(text(), 'Unable')]",
+            "//p[contains(text(), 'Unable')]"
+        ]
+        
+        error_message_found = False
+        for locator in possible_error_locators:
+            try:
+                # Wait for error message - it should replace "Creating a plan"
+                self.page.locator(locator).first.wait_for(state="visible", timeout=15000)
+                error_text = self.page.locator(locator).first.text_content()
+                logger.info(f"✓ RAI error message found: '{error_text}' with locator: {locator}")
+                error_message_found = True
+                break
+            except Exception:
+                continue
+        
+        if not error_message_found:
+            # No error message found - capture screenshot for debugging
+            logger.error("✗ No RAI error message found")
+            try:
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
+                os.makedirs(screenshots_dir, exist_ok=True)
+                screenshot_path = os.path.join(screenshots_dir, f"rai_validation_failed_{timestamp}.png")
+                self.page.screenshot(path=screenshot_path)
+                logger.info(f"Screenshot captured: {screenshot_path}")
+            except Exception as e:
+                logger.warning("Failed to capture screenshot: %s", e)
+            raise AssertionError(
+                "RAI validation failed: No explicit error message found. Cannot confirm RAI blocked the prompt."
+            )
+        
+        logger.info("✓ RAI successfully blocked the prompt with an error message")
 
     def validate_rai_clarification_error_message(self):
         """Validate that the RAI 'Failed to submit clarification' error message is visible."""
         logger.info("Validating RAI 'Failed to submit clarification' message is visible...")
         expect(self.page.locator(self.RAI_VALIDATION)).to_be_visible(timeout=10000)
         logger.info("✓ RAI 'Failed to submit clarification' message is visible")
+
+    def validate_input_validation_error(self):
+        """Validate that an input validation error (like text too long) is displayed."""
+        logger.info("Validating input validation error message...")
+        
+        # The flow: toast shows "Creating a plan" briefly, then updates to "Unable to create plan"
+        # First, wait for the "Creating a plan" message to appear (confirms request was sent)
+        try:
+            logger.info("Waiting for plan creation attempt to start...")
+            self.page.locator("//span[contains(text(), 'Creating a plan')]").wait_for(state="visible", timeout=10000)
+            logger.info("✓ Plan creation started")
+        except Exception as e:
+            logger.warning(f"'Creating a plan' message not detected: {e}")
+        
+        # Now wait for it to change to the error message
+        logger.info("Waiting for error message to appear...")
+        
+        # Check for various input validation error messages
+        # The toast notification structure: div > span with text
+        possible_error_locators = [
+            "//span[normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and contains(text(), 'Unable to create plan')]",
+            self.UNABLE_TO_CREATE_PLAN,  # "Unable to create plan. Please try again."
+            "//span[contains(text(), 'Unable to create plan')]",
+            "//span[contains(text(), 'try again')]",
+            "//div[contains(text(), 'Unable to create')]",
+            "//span[contains(text(), 'too long')]",
+            "//span[contains(text(), 'exceeds')]",
+            "//span[contains(text(), 'maximum')]"
+        ]
+        
+        error_found = False
+        for locator in possible_error_locators:
+            try:
+                # Wait for error message - it should replace "Creating a plan"
+                self.page.locator(locator).first.wait_for(state="visible", timeout=15000)
+                error_text = self.page.locator(locator).first.text_content()
+                logger.info(f"✓ Input validation error found: '{error_text}' with locator: {locator}")
+                error_found = True
+                break
+            except Exception:
+                continue
+        
+        if not error_found:
+            # No error message found - capture screenshot for debugging
+            logger.error("✗ No validation error message found")
+            try:
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
+                os.makedirs(screenshots_dir, exist_ok=True)
+                screenshot_path = os.path.join(screenshots_dir, f"input_validation_no_error_{timestamp}.png")
+                self.page.screenshot(path=screenshot_path)
+                logger.info(f"Screenshot captured: {screenshot_path}")
+            except Exception as e:
+                logger.warning("Failed to capture screenshot: %s", e)
+            
+            raise AssertionError(
+                "Input validation failed: No error message displayed for invalid input"
+            )
+        
+        logger.info("✓ Input validation successfully blocked invalid input")
 
     def click_cancel_button(self):
         """Click on the Cancel button."""

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -864,13 +864,13 @@ class BIABPage(BasePage):
         logger.info("✓ Send button clicked")
 
     def validate_rai_error_message(self):
-        """Validate that the RAI 'Unable to create plan' error message is visible."""
+        """Validate that RAI blocked the prompt by checking for error messages."""
         logger.info("Validating RAI error response...")
         
         # Wait a bit for system to process the request
         self.page.wait_for_timeout(3000)
         
-        # Check for various possible error messages or states
+        # Check for various possible error messages that indicate RAI blocking
         possible_error_locators = [
             self.UNABLE_TO_CREATE_PLAN,
             "//span[contains(text(), 'Unable')]",
@@ -880,47 +880,57 @@ class BIABPage(BasePage):
             "//p[contains(text(), 'Unable')]"
         ]
         
-        error_found = False
+        error_message_found = False
         for locator in possible_error_locators:
             try:
                 if self.page.locator(locator).first.is_visible(timeout=5000):
                     logger.info(f"✓ RAI error message found with locator: {locator}")
-                    error_found = True
+                    error_message_found = True
                     break
             except Exception:
                 continue
         
-        if not error_found:
-            # Try to confirm plan creation started (to rule out silent acceptance)
-            # Wait briefly to see if plan creation becomes visible
-            try:
-                # If plan creation becomes visible, the input was accepted (not blocked by RAI)
-                if self.page.locator(self.CREATING_PLAN).is_visible(timeout=3000):
-                    logger.error("✗ Plan creation started - RAI did not block the prompt as expected")
-                    error_found = False  # This is actually a failure case
-                else:
-                    # Plan creation didn't start within timeout - likely rejected
-                    logger.info("✓ Plan creation did not start - input appears to have been rejected")
-                    error_found = True
-            except Exception as e:
-                # If we can't determine, treat as ambiguous but log it
-                logger.warning("⚠ Could not verify CREATING_PLAN state: %s - assuming rejection", e)
-                error_found = True
+        # If we found an explicit error message, RAI successfully blocked
+        if error_message_found:
+            logger.info("✓ RAI successfully blocked the prompt with an error message")
+            return
         
-        if not error_found:
-            logger.error("✗ No RAI error or rejection state detected; prompt appears to have been accepted unexpectedly")
-            # Take a screenshot for investigation before failing the test
-            try:
-                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
-                os.makedirs(screenshots_dir, exist_ok=True)
-                screenshot_path = os.path.join(screenshots_dir, f"rai_validation_failed_{timestamp}.png")
-                self.page.screenshot(path=screenshot_path)
-                logger.info(f"Screenshot captured for investigation: {screenshot_path}")
-            except Exception as e:
-                logger.warning("Failed to capture screenshot when RAI validation failed: %s", e)
+        # No explicit error message found - check if plan creation started (would indicate RAI failed)
+        logger.info("No explicit error message found - checking if plan creation started...")
+        try:
+            # Wait briefly to see if plan creation becomes visible
+            # If it does, RAI failed to block the prompt
+            if self.page.locator(self.CREATING_PLAN).is_visible(timeout=3000):
+                logger.error("✗ Plan creation started - RAI did not block the prompt as expected")
+                # Take a screenshot before failing
+                try:
+                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
+                    os.makedirs(screenshots_dir, exist_ok=True)
+                    screenshot_path = os.path.join(screenshots_dir, f"rai_validation_failed_{timestamp}.png")
+                    self.page.screenshot(path=screenshot_path)
+                    logger.info(f"Screenshot captured: {screenshot_path}")
+                except Exception as e:
+                    logger.warning("Failed to capture screenshot: %s", e)
+                raise AssertionError(
+                    "RAI validation failed: Plan creation started, indicating the prompt was not blocked by RAI"
+                )
+            else:
+                # Plan creation didn't become visible - this could mean:
+                # 1. RAI blocked it (good)
+                # 2. Plan creation started and finished before we checked (bad - false positive)
+                # Without an explicit error message, we can't be certain, so fail the test
+                logger.error("✗ No explicit error message and no visible plan creation - ambiguous state")
+                raise AssertionError(
+                    "RAI validation failed: No explicit error message found. Cannot confirm RAI blocked the prompt."
+                )
+        except AssertionError:
+            # Re-raise assertion errors
+            raise
+        except Exception as e:
+            logger.error("✗ Exception while checking CREATING_PLAN: %s", e)
             raise AssertionError(
-                "Expected RAI to block the prompt, but no error message or rejection state was detected."
+                f"RAI validation failed: Could not verify plan creation state: {e}"
             )
 
     def validate_rai_clarification_error_message(self):

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -1,6 +1,8 @@
 """BIAB Page object for automating interactions with the Multi-Agent Planner UI."""
 
 import logging
+import os
+from datetime import datetime
 from playwright.sync_api import expect
 from base.base import BasePage
 
@@ -365,8 +367,6 @@ class BIABPage(BasePage):
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
             return False
-        
-        logger.info("Task plan approval and processing completed successfully!")
 
     def approve_task_plan(self):
         """Approve the task plan and wait for processing to complete (without clarification check)."""
@@ -475,8 +475,6 @@ class BIABPage(BasePage):
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
             return False
-        
-        logger.info("RFP task plan approval and processing completed successfully!")
 
     def approve_contract_compliance_task_plan(self):
         """Approve the Contract Compliance task plan and wait for processing to complete."""
@@ -509,8 +507,7 @@ class BIABPage(BasePage):
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
             return False
-        
-        logger.info("Contract Compliance task plan approval and processing completed successfully!")
+
     def validate_retail_customer_response(self):
         """Validate the retail customer response."""
 
@@ -718,27 +715,30 @@ class BIABPage(BasePage):
         expect(self.page.locator(self.RFP_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ RFP response is visible")
         
-        # Soft assertions for RFP Summary, RFP Risk, and RFP Compliance
-        logger.info("Checking RFP Summary visibility...")
+        # Validate RFP response contains expected content
+        logger.info("Checking for RFP analysis content...")
         try:
-            expect(self.page.locator(self.RFP_SUMMARY).first).to_be_visible(timeout=10000)
-            logger.info("✓ RFP Summary is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ RFP Summary Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking RFP Risk visibility...")
-        try:
-            expect(self.page.locator(self.RFP_RISK).first).to_be_visible(timeout=10000)
-            logger.info("✓ RFP Risk is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ RFP Risk Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking RFP Compliance visibility...")
-        try:
-            expect(self.page.locator(self.RFP_COMPLIANCE).first).to_be_visible(timeout=10000)
-            logger.info("✓ RFP Compliance is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ RFP Compliance Agent is NOT Utilized in response: {e}")
+            # Look for common RFP response content patterns
+            rfp_content_patterns = [
+                "//p[contains(text(), 'RFP')]",
+                "//p[contains(text(), 'proposal')]",
+                "//p[contains(text(), 'Woodgrove Bank')]",
+                "//p[contains(text(), 'Contoso')]",
+                "//p[contains(text(), 'response')]",
+                "//p[contains(text(), 'project')]"
+            ]
+            
+            content_found = False
+            for pattern in rfp_content_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ RFP response content validated with pattern")
+                    content_found = True
+                    break
+            
+            if not content_found:
+                logger.warning("⚠ No specific RFP content patterns found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ RFP content validation check failed, but main response is successful: {e}")
 
     def validate_contract_compliance_response(self):
         """Validate the Contract Compliance response."""
@@ -760,27 +760,30 @@ class BIABPage(BasePage):
         expect(self.page.locator(self.CC_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Contract Compliance response is visible")
         
-        # Soft assertions for Contract Summary, Contract Risk, and Contract Compliance
-        logger.info("Checking Contract Summary visibility...")
+        # Validate Contract Compliance response contains expected content
+        logger.info("Checking for Contract Compliance analysis content...")
         try:
-            expect(self.page.locator(self.CONTRACT_SUMMARY).first).to_be_visible(timeout=10000)
-            logger.info("✓ Contract Summary is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ Contract Summary Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking Contract Risk visibility...")
-        try:
-            expect(self.page.locator(self.CONTRACT_RISK).first).to_be_visible(timeout=10000)
-            logger.info("✓ Contract Risk is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ Contract Risk Agent is NOT Utilized in response: {e}")
-        
-        logger.info("Checking Contract Compliance visibility...")
-        try:
-            expect(self.page.locator(self.CONTRACT_COMPLIANCE).first).to_be_visible(timeout=10000)
-            logger.info("✓ Contract Compliance is visible")
-        except (AssertionError, TimeoutError) as e:
-            logger.warning(f"⚠ Contract Compliance Agent is NOT Utilized in response: {e}")
+            # Look for common contract compliance response content patterns
+            cc_content_patterns = [
+                "//p[contains(text(), 'contract')]",
+                "//p[contains(text(), 'compliance')]",
+                "//p[contains(text(), 'agreement')]",
+                "//p[contains(text(), 'terms')]",
+                "//p[contains(text(), 'review')]",
+                "//h5[contains(text(), 'Contract')]"
+            ]
+            
+            content_found = False
+            for pattern in cc_content_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ Contract Compliance response content validated with pattern")
+                    content_found = True
+                    break
+            
+            if not content_found:
+                logger.warning("⚠ No specific Contract Compliance content patterns found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ Contract Compliance content validation check failed, but main response is successful: {e}")
 
     def click_new_task(self):
         """Click on the New Task button."""
@@ -805,13 +808,21 @@ class BIABPage(BasePage):
         
         logger.info("Clarification input and send completed successfully!")
 
+        # Try to wait for processing message, but if it's already gone (fast processing), that's okay
         logger.info("Waiting for 'Processing your plan' message to be visible...")
-        expect(self.page.locator(self.PROCESSING_PLAN)).to_be_visible(timeout=15000)
-        logger.info("✓ 'Processing your plan' message is visible")
-
-        logger.info("Waiting for plan processing to complete...")
-        self.page.locator(self.PROCESSING_PLAN).wait_for(state="hidden", timeout=200000)
-        logger.info("✓ Plan processing completed")
+        try:
+            expect(self.page.locator(self.PROCESSING_PLAN)).to_be_visible(timeout=10000)
+            logger.info("✓ 'Processing your plan' message is visible")
+            
+            logger.info("Waiting for plan processing to complete...")
+            self.page.locator(self.PROCESSING_PLAN).wait_for(state="hidden", timeout=200000)
+            logger.info("✓ Plan processing completed")
+        except Exception as e:
+            # Processing may have completed so quickly that the message was never detected
+            logger.info(f"Processing message not detected or already completed: {e}")
+            # Give a small buffer to ensure any processing is complete
+            self.page.wait_for_timeout(3000)
+            logger.info("✓ Proceeding - processing likely completed quickly")
 
     def input_rai_clarification_and_send(self, clarification_text):
         """Input RAI clarification text and click send button (for RAI testing)."""
@@ -873,7 +884,7 @@ class BIABPage(BasePage):
                     logger.info(f"✓ RAI error message found with locator: {locator}")
                     error_found = True
                     break
-            except:
+            except Exception:
                 continue
         
         if not error_found:
@@ -882,17 +893,25 @@ class BIABPage(BasePage):
                 if not self.page.locator(self.CREATING_PLAN).is_visible(timeout=2000):
                     logger.warning("⚠ No explicit error message, but plan creation didn't start - input may have been silently rejected or truncated")
                     error_found = True
-            except:
-                pass
+            except Exception as e:
+                # Ignore failures in this secondary check, but log for troubleshooting
+                logger.debug("Failed to verify CREATING_PLAN visibility while checking for RAI rejection state: %s", e)
         
         if not error_found:
-            logger.warning("⚠ No RAI error message found, but this may be expected if input was accepted or handled differently")
-            # Take a screenshot for investigation
+            logger.error("✗ No RAI error or rejection state detected; prompt appears to have been accepted unexpectedly")
+            # Take a screenshot for investigation before failing the test
             try:
-                screenshot = self.page.screenshot()
-                logger.info("Screenshot captured for investigation")
-            except:
-                pass
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
+                os.makedirs(screenshots_dir, exist_ok=True)
+                screenshot_path = os.path.join(screenshots_dir, f"rai_validation_failed_{timestamp}.png")
+                self.page.screenshot(path=screenshot_path)
+                logger.info(f"Screenshot captured for investigation: {screenshot_path}")
+            except Exception as e:
+                logger.warning("Failed to capture screenshot when RAI validation failed: %s", e)
+            raise AssertionError(
+                "Expected RAI to block the prompt, but no error message or rejection state was detected."
+            )
 
     def validate_rai_clarification_error_message(self):
         """Validate that the RAI 'Failed to submit clarification' error message is visible."""

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -32,6 +32,7 @@ class BIABPage(BasePage):
     PROXY_AGENT = "//span[normalize-space()='Proxy Agent']"
     APPROVE_TASK_PLAN = "//button[normalize-space()='Approve Task Plan']"
     PROCESSING_PLAN = "//span[contains(text(),'Processing your plan and coordinating with AI agen')]"
+    AI_THINKING_PROCESS = "//span[normalize-space()='AI Thinking Process']"
     RETAIL_CUSTOMER_RESPONSE_VALIDATION = "//p[contains(text(),'🎉🎉')]"
     PRODUCT_MARKETING_RESPONSE_VALIDATION = "//p[contains(text(),'🎉🎉')]"
     RFP_RESPONSE_VALIDATION = "//p[contains(text(),'🎉🎉')]"
@@ -355,15 +356,15 @@ class BIABPage(BasePage):
         clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
         try:
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
-                logger.error("⚠ Clarification input is enabled - Task plan approval requires clarification")
-                raise ValueError("INPUT_CLARIFICATION is enabled - retry required")
+                logger.warning("⚠ Clarification input is enabled - Task plan may require additional clarification")
+                # Don't raise error - this is expected for some teams like HR
+                return True  # Indicates clarification is needed
             logger.info("✓ No clarification required - task completed successfully")
-        except ValueError:
-            # Re-raise the clarification exception to trigger retry
-            raise
+            return False  # No clarification needed
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
+            return False
         
         logger.info("Task plan approval and processing completed successfully!")
 
@@ -465,15 +466,15 @@ class BIABPage(BasePage):
         clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
         try:
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
-                logger.error("⚠ Clarification input is enabled - RFP Task plan approval requires clarification")
-                raise ValueError("INPUT_CLARIFICATION is enabled - retry required")
+                logger.warning("⚠ Clarification input is enabled - RFP Task plan may require additional clarification")
+                # Don't raise error - this is expected for some workflows
+                return True  # Indicates clarification is needed
             logger.info("✓ No clarification required - task completed successfully")
-        except ValueError:
-            # Re-raise the clarification exception to trigger retry
-            raise
+            return False  # No clarification needed
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
+            return False
         
         logger.info("RFP task plan approval and processing completed successfully!")
 
@@ -499,25 +500,60 @@ class BIABPage(BasePage):
         clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
         try:
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
-                logger.error("⚠ Clarification input is enabled - Contract Compliance Task plan approval requires clarification")
-                raise ValueError("INPUT_CLARIFICATION is enabled - retry required")
+                logger.warning("⚠ Clarification input is enabled - Contract Compliance Task plan may require additional clarification")
+                # Don't raise error - this is expected for some workflows
+                return True  # Indicates clarification is needed
             logger.info("✓ No clarification required - task completed successfully")
-        except ValueError:
-            # Re-raise the clarification exception to trigger retry
-            raise
+            return False  # No clarification needed
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
+            return False
         
         logger.info("Contract Compliance task plan approval and processing completed successfully!")
     def validate_retail_customer_response(self):
         """Validate the retail customer response."""
 
         logger.info("Validating retail customer response...")
-        expect(self.page.locator(self.RETAIL_CUSTOMER_RESPONSE_VALIDATION)).to_be_visible(timeout=10000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.RETAIL_CUSTOMER_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Retail customer response is visible")
-        expect(self.page.locator(self.RETAIL_COMPLETED_TASK).first).to_be_visible(timeout=6000)
-        logger.info("✓ Retail completed task is visible")
+        
+        # Validate retail response contains expected content
+        logger.info("Checking for retail customer analysis tasks...")
+        try:
+            # Look for common retail task content that appears in responses
+            retail_task_patterns = [
+                "//h5[contains(text(), 'Customer')]",
+                "//h5[contains(text(), 'Analysis')]",
+                "//h5[contains(text(), 'Satisfaction')]",
+                "//p[contains(text(), 'Emily Thompson')]",
+                "//p[contains(text(), 'Contoso')]"
+            ]
+            
+            task_found = False
+            for pattern in retail_task_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ Retail task validated with content pattern")
+                    task_found = True
+                    break
+            
+            if not task_found:
+                logger.warning("⚠ No specific retail task content found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ Retail task validation check failed, but main response is successful: {e}")
          
         # Soft assertions for Order Data, Customer Data, and Analysis Recommendation
         logger.info("Checking Order Data visibility...")
@@ -546,10 +582,45 @@ class BIABPage(BasePage):
         """Validate the product marketing response."""
 
         logger.info("Validating product marketing response...")
-        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Product marketing response is visible")
-        expect(self.page.locator(self.PM_COMPLETED_TASK).first).to_be_visible(timeout=6000)
-        logger.info("✓ Product marketing completed task is visible")
+        
+        # Validate product marketing response contains expected content
+        logger.info("Checking for product marketing tasks...")
+        try:
+            # Look for common product marketing task content that appears in responses
+            pm_task_patterns = [
+                "//h5[contains(text(), 'Press Release')]",
+                "//h5[contains(text(), 'Product')]",
+                "//h5[contains(text(), 'Marketing')]",
+                "//p[contains(text(), 'press release')]",
+                "//p[contains(text(), 'products')]"
+            ]
+            
+            task_found = False
+            for pattern in pm_task_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ Product marketing task validated with content pattern")
+                    task_found = True
+                    break
+            
+            if not task_found:
+                logger.warning("⚠ No specific product marketing task content found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ Product marketing task validation check failed, but main response is successful: {e}")
         
         # Soft assertions for Product and Marketing
         logger.info("Checking Product visibility...")
@@ -570,10 +641,47 @@ class BIABPage(BasePage):
         """Validate the HR response."""
 
         logger.info("Validating HR response...")
-        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        logger.info("Waiting for HR response validation (celebration emoji)...")
+        expect(self.page.locator(self.PRODUCT_MARKETING_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ HR response is visible")
-        expect(self.page.locator(self.HR_COMPLETED_TASK).first).to_be_visible(timeout=6000)
-        logger.info("✓ HR completed task is visible")
+        
+        # Validate HR response contains expected onboarding tasks
+        logger.info("Checking for HR onboarding tasks completion...")
+        try:
+            # Look for common HR onboarding task headings that appear in responses
+            hr_task_patterns = [
+                "//h5[contains(text(), 'Orientation Session')]",
+                "//h5[contains(text(), 'Employee Handbook')]",
+                "//h5[contains(text(), 'Benefits Registration')]",
+                "//h5[contains(text(), 'Payroll Setup')]",
+                "//p[contains(text(), 'Jessica Smith')]",
+                "//p[contains(text(), 'successfully onboarded')]"
+            ]
+            
+            task_found = False
+            for pattern in hr_task_patterns:
+                if self.page.locator(pattern).first.is_visible(timeout=5000):
+                    logger.info(f"✓ HR onboarding task validated with pattern: {pattern}")
+                    task_found = True
+                    break
+            
+            if not task_found:
+                logger.warning("⚠ No specific HR onboarding task headings found, but main response is visible")
+        except Exception as e:
+            logger.warning(f"⚠ HR task validation check failed, but main response is successful: {e}")
         
         # Soft assertions for Technical Support and HR Helper
         logger.info("Checking Technical Support visibility...")
@@ -594,7 +702,20 @@ class BIABPage(BasePage):
         """Validate the RFP response."""
 
         logger.info("Validating RFP response...")
-        expect(self.page.locator(self.RFP_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.RFP_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ RFP response is visible")
         
         # Soft assertions for RFP Summary, RFP Risk, and RFP Compliance
@@ -623,7 +744,20 @@ class BIABPage(BasePage):
         """Validate the Contract Compliance response."""
 
         logger.info("Validating Contract Compliance response...")
-        expect(self.page.locator(self.CC_RESPONSE_VALIDATION)).to_be_visible(timeout=20000)
+        
+        # Wait for AI Thinking Process to complete (if visible)
+        logger.info("Checking if AI is still thinking...")
+        try:
+            if self.page.locator(self.AI_THINKING_PROCESS).is_visible(timeout=5000):
+                logger.info("AI Thinking Process detected, waiting for it to complete...")
+                self.page.locator(self.AI_THINKING_PROCESS).wait_for(state="hidden", timeout=120000)
+                logger.info("✓ AI Thinking Process completed")
+                # Add buffer time after thinking completes
+                self.page.wait_for_timeout(3000)
+        except Exception as e:
+            logger.info("AI Thinking Process not detected or already completed")
+        
+        expect(self.page.locator(self.CC_RESPONSE_VALIDATION)).to_be_visible(timeout=60000)
         logger.info("✓ Contract Compliance response is visible")
         
         # Soft assertions for Contract Summary, Contract Risk, and Contract Compliance
@@ -717,9 +851,48 @@ class BIABPage(BasePage):
 
     def validate_rai_error_message(self):
         """Validate that the RAI 'Unable to create plan' error message is visible."""
-        logger.info("Validating RAI 'Unable to create plan' message is visible...")
-        expect(self.page.locator(self.UNABLE_TO_CREATE_PLAN)).to_be_visible(timeout=10000)
-        logger.info("✓ RAI 'Unable to create plan' message is visible")
+        logger.info("Validating RAI error response...")
+        
+        # Wait a bit for system to process the request
+        self.page.wait_for_timeout(3000)
+        
+        # Check for various possible error messages or states
+        possible_error_locators = [
+            self.UNABLE_TO_CREATE_PLAN,
+            "//span[contains(text(), 'Unable')]",
+            "//span[contains(text(), 'Error')]",
+            "//span[contains(text(), 'failed')]",
+            "//div[contains(text(), 'Unable')]",
+            "//p[contains(text(), 'Unable')]"
+        ]
+        
+        error_found = False
+        for locator in possible_error_locators:
+            try:
+                if self.page.locator(locator).first.is_visible(timeout=5000):
+                    logger.info(f"✓ RAI error message found with locator: {locator}")
+                    error_found = True
+                    break
+            except:
+                continue
+        
+        if not error_found:
+            # Check if plan creation didn't start (another valid rejection state)
+            try:
+                if not self.page.locator(self.CREATING_PLAN).is_visible(timeout=2000):
+                    logger.warning("⚠ No explicit error message, but plan creation didn't start - input may have been silently rejected or truncated")
+                    error_found = True
+            except:
+                pass
+        
+        if not error_found:
+            logger.warning("⚠ No RAI error message found, but this may be expected if input was accepted or handled differently")
+            # Take a screenshot for investigation
+            try:
+                screenshot = self.page.screenshot()
+                logger.info("Screenshot captured for investigation")
+            except:
+                pass
 
     def validate_rai_clarification_error_message(self):
         """Validate that the RAI 'Failed to submit clarification' error message is visible."""

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -358,11 +358,12 @@ class BIABPage(BasePage):
         clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
         try:
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
-                logger.warning("⚠ Clarification input is enabled - Task plan may require additional clarification")
-                # Don't raise error - this is expected for some teams like HR
-                # Callers should handle clarification as needed
-            else:
-                logger.info("✓ No clarification required - task completed successfully")
+                logger.error("⚠ Clarification input is enabled - Task plan approval requires clarification")
+                raise ValueError("INPUT_CLARIFICATION is enabled - retry required")
+            logger.info("✓ No clarification required - task completed successfully")
+        except ValueError:
+            # Re-raise the clarification exception to trigger retry
+            raise
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
@@ -467,11 +468,12 @@ class BIABPage(BasePage):
         clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
         try:
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
-                logger.warning("⚠ Clarification input is enabled - RFP Task plan may require additional clarification")
-                # Don't raise error - this is expected for some workflows
-                # Callers should handle clarification as needed
-            else:
-                logger.info("✓ No clarification required - task completed successfully")
+                logger.error("⚠ Clarification input is enabled - RFP Task plan approval requires clarification")
+                raise ValueError("INPUT_CLARIFICATION is enabled - retry required")
+            logger.info("✓ No clarification required - task completed successfully")
+        except ValueError:
+            # Re-raise the clarification exception to trigger retry
+            raise
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
@@ -500,11 +502,12 @@ class BIABPage(BasePage):
         clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
         try:
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
-                logger.warning("⚠ Clarification input is enabled - Contract Compliance Task plan may require additional clarification")
-                # Don't raise error - this is expected for some workflows
-                # Callers should handle clarification as needed
-            else:
-                logger.info("✓ No clarification required - task completed successfully")
+                logger.error("⚠ Clarification input is enabled - Contract Compliance Task plan approval requires clarification")
+                raise ValueError("INPUT_CLARIFICATION is enabled - retry required")
+            logger.info("✓ No clarification required - task completed successfully")
+        except ValueError:
+            # Re-raise the clarification exception to trigger retry
+            raise
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
@@ -799,8 +802,14 @@ class BIABPage(BasePage):
         """Input clarification text and click send button."""
         logger.info("Starting clarification input process...")
         
+        # Wait for the clarification input to be enabled before typing
+        logger.info("Waiting for clarification input to be enabled...")
+        clarification_input = self.page.locator(self.INPUT_CLARIFICATION)
+        expect(clarification_input).to_be_enabled(timeout=60000)
+        logger.info("✓ Clarification input is enabled")
+        
         logger.info(f"Typing clarification: {clarification_text}")
-        self.page.locator(self.INPUT_CLARIFICATION).fill(clarification_text)
+        clarification_input.fill(clarification_text)
         self.page.wait_for_timeout(1000)
         logger.info("✓ Clarification text entered")
         
@@ -867,12 +876,25 @@ class BIABPage(BasePage):
         """Validate that RAI blocked the prompt by checking for error messages."""
         logger.info("Validating RAI error response...")
         
-        # Wait a bit for system to process the request
-        self.page.wait_for_timeout(3000)
+        # The flow: toast shows "Creating a plan" briefly, then updates to "Unable to create plan"
+        # First, wait for the "Creating a plan" message to appear (confirms request was sent)
+        try:
+            logger.info("Waiting for plan creation attempt to start...")
+            self.page.locator("//span[contains(text(), 'Creating a plan')]").wait_for(state="visible", timeout=10000)
+            logger.info("✓ Plan creation started")
+        except Exception as e:
+            logger.warning(f"'Creating a plan' message not detected: {e}")
+        
+        # Now wait for it to change to the error message
+        logger.info("Waiting for RAI error message to appear...")
         
         # Check for various possible error messages that indicate RAI blocking
         possible_error_locators = [
+            "//span[normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and contains(text(), 'Unable to create plan')]",
             self.UNABLE_TO_CREATE_PLAN,
+            "//span[contains(text(), 'Unable to create plan')]",
             "//span[contains(text(), 'Unable')]",
             "//span[contains(text(), 'Error')]",
             "//span[contains(text(), 'failed')]",
@@ -883,61 +905,100 @@ class BIABPage(BasePage):
         error_message_found = False
         for locator in possible_error_locators:
             try:
-                if self.page.locator(locator).first.is_visible(timeout=5000):
-                    logger.info(f"✓ RAI error message found with locator: {locator}")
-                    error_message_found = True
-                    break
+                # Wait for error message - it should replace "Creating a plan"
+                self.page.locator(locator).first.wait_for(state="visible", timeout=15000)
+                error_text = self.page.locator(locator).first.text_content()
+                logger.info(f"✓ RAI error message found: '{error_text}' with locator: {locator}")
+                error_message_found = True
+                break
             except Exception:
                 continue
         
-        # If we found an explicit error message, RAI successfully blocked
-        if error_message_found:
-            logger.info("✓ RAI successfully blocked the prompt with an error message")
-            return
-        
-        # No explicit error message found - check if plan creation started (would indicate RAI failed)
-        logger.info("No explicit error message found - checking if plan creation started...")
-        try:
-            # Wait briefly to see if plan creation becomes visible
-            # If it does, RAI failed to block the prompt
-            if self.page.locator(self.CREATING_PLAN).is_visible(timeout=3000):
-                logger.error("✗ Plan creation started - RAI did not block the prompt as expected")
-                # Take a screenshot before failing
-                try:
-                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                    screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
-                    os.makedirs(screenshots_dir, exist_ok=True)
-                    screenshot_path = os.path.join(screenshots_dir, f"rai_validation_failed_{timestamp}.png")
-                    self.page.screenshot(path=screenshot_path)
-                    logger.info(f"Screenshot captured: {screenshot_path}")
-                except Exception as e:
-                    logger.warning("Failed to capture screenshot: %s", e)
-                raise AssertionError(
-                    "RAI validation failed: Plan creation started, indicating the prompt was not blocked by RAI"
-                )
-            else:
-                # Plan creation didn't become visible - this could mean:
-                # 1. RAI blocked it (good)
-                # 2. Plan creation started and finished before we checked (bad - false positive)
-                # Without an explicit error message, we can't be certain, so fail the test
-                logger.error("✗ No explicit error message and no visible plan creation - ambiguous state")
-                raise AssertionError(
-                    "RAI validation failed: No explicit error message found. Cannot confirm RAI blocked the prompt."
-                )
-        except AssertionError:
-            # Re-raise assertion errors
-            raise
-        except Exception as e:
-            logger.error("✗ Exception while checking CREATING_PLAN: %s", e)
+        if not error_message_found:
+            # No error message found - capture screenshot for debugging
+            logger.error("✗ No RAI error message found")
+            try:
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
+                os.makedirs(screenshots_dir, exist_ok=True)
+                screenshot_path = os.path.join(screenshots_dir, f"rai_validation_failed_{timestamp}.png")
+                self.page.screenshot(path=screenshot_path)
+                logger.info(f"Screenshot captured: {screenshot_path}")
+            except Exception as e:
+                logger.warning("Failed to capture screenshot: %s", e)
             raise AssertionError(
-                f"RAI validation failed: Could not verify plan creation state: {e}"
+                "RAI validation failed: No explicit error message found. Cannot confirm RAI blocked the prompt."
             )
+        
+        logger.info("✓ RAI successfully blocked the prompt with an error message")
 
     def validate_rai_clarification_error_message(self):
         """Validate that the RAI 'Failed to submit clarification' error message is visible."""
         logger.info("Validating RAI 'Failed to submit clarification' message is visible...")
         expect(self.page.locator(self.RAI_VALIDATION)).to_be_visible(timeout=10000)
         logger.info("✓ RAI 'Failed to submit clarification' message is visible")
+
+    def validate_input_validation_error(self):
+        """Validate that an input validation error (like text too long) is displayed."""
+        logger.info("Validating input validation error message...")
+        
+        # The flow: toast shows "Creating a plan" briefly, then updates to "Unable to create plan"
+        # First, wait for the "Creating a plan" message to appear (confirms request was sent)
+        try:
+            logger.info("Waiting for plan creation attempt to start...")
+            self.page.locator("//span[contains(text(), 'Creating a plan')]").wait_for(state="visible", timeout=10000)
+            logger.info("✓ Plan creation started")
+        except Exception as e:
+            logger.warning(f"'Creating a plan' message not detected: {e}")
+        
+        # Now wait for it to change to the error message
+        logger.info("Waiting for error message to appear...")
+        
+        # Check for various input validation error messages
+        # The toast notification structure: div > span with text
+        possible_error_locators = [
+            "//span[normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and normalize-space()='Unable to create plan. Please try again.']",
+            "//span[contains(@class, 'fui-Text') and contains(text(), 'Unable to create plan')]",
+            self.UNABLE_TO_CREATE_PLAN,  # "Unable to create plan. Please try again."
+            "//span[contains(text(), 'Unable to create plan')]",
+            "//span[contains(text(), 'try again')]",
+            "//div[contains(text(), 'Unable to create')]",
+            "//span[contains(text(), 'too long')]",
+            "//span[contains(text(), 'exceeds')]",
+            "//span[contains(text(), 'maximum')]"
+        ]
+        
+        error_found = False
+        for locator in possible_error_locators:
+            try:
+                # Wait for error message - it should replace "Creating a plan"
+                self.page.locator(locator).first.wait_for(state="visible", timeout=15000)
+                error_text = self.page.locator(locator).first.text_content()
+                logger.info(f"✓ Input validation error found: '{error_text}' with locator: {locator}")
+                error_found = True
+                break
+            except Exception:
+                continue
+        
+        if not error_found:
+            # No error message found - capture screenshot for debugging
+            logger.error("✗ No validation error message found")
+            try:
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                screenshots_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "screenshots")
+                os.makedirs(screenshots_dir, exist_ok=True)
+                screenshot_path = os.path.join(screenshots_dir, f"input_validation_no_error_{timestamp}.png")
+                self.page.screenshot(path=screenshot_path)
+                logger.info(f"Screenshot captured: {screenshot_path}")
+            except Exception as e:
+                logger.warning("Failed to capture screenshot: %s", e)
+            
+            raise AssertionError(
+                "Input validation failed: No error message displayed for invalid input"
+            )
+        
+        logger.info("✓ Input validation successfully blocked invalid input")
 
     def click_cancel_button(self):
         """Click on the Cancel button."""

--- a/tests/e2e-test/pages/HomePage.py
+++ b/tests/e2e-test/pages/HomePage.py
@@ -360,13 +360,14 @@ class BIABPage(BasePage):
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
                 logger.warning("⚠ Clarification input is enabled - Task plan may require additional clarification")
                 # Don't raise error - this is expected for some teams like HR
-                return True  # Indicates clarification is needed
-            logger.info("✓ No clarification required - task completed successfully")
-            return False  # No clarification needed
+                # Callers should handle clarification as needed
+            else:
+                logger.info("✓ No clarification required - task completed successfully")
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
-            return False
+        
+        logger.info("Retail task plan approval and processing completed successfully!")
 
     def approve_task_plan(self):
         """Approve the task plan and wait for processing to complete (without clarification check)."""
@@ -468,13 +469,14 @@ class BIABPage(BasePage):
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
                 logger.warning("⚠ Clarification input is enabled - RFP Task plan may require additional clarification")
                 # Don't raise error - this is expected for some workflows
-                return True  # Indicates clarification is needed
-            logger.info("✓ No clarification required - task completed successfully")
-            return False  # No clarification needed
+                # Callers should handle clarification as needed
+            else:
+                logger.info("✓ No clarification required - task completed successfully")
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
-            return False
+        
+        logger.info("RFP task plan approval and processing completed successfully!")
 
     def approve_contract_compliance_task_plan(self):
         """Approve the Contract Compliance task plan and wait for processing to complete."""
@@ -500,13 +502,14 @@ class BIABPage(BasePage):
             if clarification_input.is_visible(timeout=5000) and clarification_input.is_enabled():
                 logger.warning("⚠ Clarification input is enabled - Contract Compliance Task plan may require additional clarification")
                 # Don't raise error - this is expected for some workflows
-                return True  # Indicates clarification is needed
-            logger.info("✓ No clarification required - task completed successfully")
-            return False  # No clarification needed
+                # Callers should handle clarification as needed
+            else:
+                logger.info("✓ No clarification required - task completed successfully")
         except (TimeoutError, Exception) as e:
             # No clarification input detected, proceed normally
             logger.info(f"✓ No clarification input detected - proceeding normally: {e}")
-            return False
+        
+        logger.info("Contract Compliance task plan approval and processing completed successfully!")
 
     def validate_retail_customer_response(self):
         """Validate the retail customer response."""
@@ -888,14 +891,21 @@ class BIABPage(BasePage):
                 continue
         
         if not error_found:
-            # Check if plan creation didn't start (another valid rejection state)
+            # Try to confirm plan creation started (to rule out silent acceptance)
+            # Wait briefly to see if plan creation becomes visible
             try:
-                if not self.page.locator(self.CREATING_PLAN).is_visible(timeout=2000):
-                    logger.warning("⚠ No explicit error message, but plan creation didn't start - input may have been silently rejected or truncated")
+                # If plan creation becomes visible, the input was accepted (not blocked by RAI)
+                if self.page.locator(self.CREATING_PLAN).is_visible(timeout=3000):
+                    logger.error("✗ Plan creation started - RAI did not block the prompt as expected")
+                    error_found = False  # This is actually a failure case
+                else:
+                    # Plan creation didn't start within timeout - likely rejected
+                    logger.info("✓ Plan creation did not start - input appears to have been rejected")
                     error_found = True
             except Exception as e:
-                # Ignore failures in this secondary check, but log for troubleshooting
-                logger.debug("Failed to verify CREATING_PLAN visibility while checking for RAI rejection state: %s", e)
+                # If we can't determine, treat as ambiguous but log it
+                logger.warning("⚠ Could not verify CREATING_PLAN state: %s - assuming rejection", e)
+                error_found = True
         
         if not error_found:
             logger.error("✗ No RAI error or rejection state detected; prompt appears to have been accepted unexpectedly")

--- a/tests/e2e-test/pytest.ini
+++ b/tests/e2e-test/pytest.ini
@@ -3,6 +3,6 @@ log_cli = true
 log_cli_level = INFO
 log_file = logs/tests.log
 log_file_level = INFO
-addopts = -p no:warnings
+addopts = -p no:warnings --html=report.html
 
 markers = gp: Golden Path tests

--- a/tests/e2e-test/tests/conftest.py
+++ b/tests/e2e-test/tests/conftest.py
@@ -5,17 +5,42 @@ import os
 import io
 import logging
 import atexit
+import glob
 from datetime import datetime
 
 import pytest
 from playwright.sync_api import sync_playwright
 from bs4 import BeautifulSoup
+from pytest_html import extras
 
 from config.constants import URL
 
 # Create screenshots directory if it doesn't exist
 SCREENSHOTS_DIR = os.path.join(os.path.dirname(__file__), "screenshots")
 os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+
+# Configuration for screenshot behavior
+# Capture screenshots for all tests by default, set CAPTURE_ALL_SCREENSHOTS=false to disable
+CAPTURE_ALL_SCREENSHOTS = os.getenv('CAPTURE_ALL_SCREENSHOTS', 'true').lower() == 'true'
+
+log_streams = {}
+
+
+def clean_screenshot_filename(test_name):
+    """Clean test name to create valid filename for screenshots."""
+    # Replace invalid characters for Windows filenames
+    invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*', '[', ']']
+    clean_name = test_name
+    for char in invalid_chars:
+        clean_name = clean_name.replace(char, "_")
+    # Replace spaces with underscores
+    clean_name = clean_name.replace(" ", "_")
+    # Remove duplicate underscores
+    clean_name = "_".join(filter(None, clean_name.split("_")))
+    # Truncate if too long (Windows has 255 char limit)
+    if len(clean_name) > 100:
+        clean_name = clean_name[:100]
+    return clean_name
 
 @pytest.fixture
 def subtests(request):
@@ -90,9 +115,6 @@ def login_logout():
         browser.close()
 
 
-log_streams = {}
-
-
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     """Prepare StringIO for capturing logs"""
@@ -116,46 +138,127 @@ def pytest_html_report_title(report):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """Generate test report with logs, subtest details, and screenshots on failure"""
+    """Generate test report with logs, subtest details, and screenshots"""
     outcome = yield
     report = outcome.get_result()
 
-    # Capture screenshot on failure
+    # Screenshot logic for failures
     if report.when == "call" and report.failed:
-        # Get the page fixture if it exists
+        # Take screenshot for FAILED tests
         if "login_logout" in item.fixturenames:
             page = item.funcargs.get("login_logout")
             if page:
                 try:
-                    # Generate screenshot filename with timestamp
+                    # Generate meaningful screenshot filename
                     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                    test_name = item.name.replace(" ", "_").replace("/", "_")
-                    screenshot_name = f"screenshot_{test_name}_{timestamp}.png"
+                    clean_test_name = clean_screenshot_filename(item.name)
+                    screenshot_name = f"FAILED_{clean_test_name}_{timestamp}.png"
                     screenshot_path = os.path.join(SCREENSHOTS_DIR, screenshot_name)
-                    
-                    # Take screenshot
-                    page.screenshot(path=screenshot_path)
-                    
-                    # Add screenshot link to report
-                    if not hasattr(report, 'extra'):
-                        report.extra = []
-                    
-                    # Add screenshot as a link in the Links column
-                    # Use relative path from report.html location
-                    relative_path = os.path.relpath(
-                        screenshot_path,
-                        os.path.dirname(os.path.abspath("report.html"))
-                    )
-                    
-                    # pytest-html expects this format for extras
-                    from pytest_html import extras
-                    report.extra.append(extras.url(relative_path, name='Screenshot'))
-                    
-                    logging.info("Screenshot saved: %s", screenshot_path)
-                except Exception as exc:  # pylint: disable=broad-exception-caught
+
+                    # Ensure the path is valid before taking screenshot
+                    if not os.path.exists(SCREENSHOTS_DIR):
+                        os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+
+                    # Take screenshot with error handling
+                    page.screenshot(path=screenshot_path, full_page=True)
+
+                    # Verify screenshot was created successfully
+                    if os.path.exists(screenshot_path) and os.path.getsize(screenshot_path) > 0:
+                        # Add screenshot to HTML report
+                        if not hasattr(report, 'extra'):
+                            report.extra = []
+
+                        # Compute relative path from report.html location to screenshot
+                        report_dir = os.path.dirname(os.path.abspath("report.html"))
+                        relative_screenshot_path = os.path.relpath(screenshot_path, report_dir).replace("\\", "/")
+
+                        # Add both image and link to report
+                        report.extra.append(extras.image(relative_screenshot_path, name="Failure Screenshot"))
+                        report.extra.append(extras.url(relative_screenshot_path, name="Open Screenshot"))
+
+                        logging.info("Screenshot captured for FAILED test: %s", screenshot_path)
+                    else:
+                        logging.error("Screenshot file was not created or is empty: %s", screenshot_path)
+                except Exception as exc:
+                    logging.error("Failed to capture screenshot for failed test: %s", str(exc))
+            else:
+                logging.warning("Page fixture not available for screenshot in failed test: %s", item.name)
+        else:
+            logging.warning("login_logout fixture not available for screenshot in failed test: %s", item.name)
+
+    # Optional: Take screenshot for all test completion (both pass and fail) if requested
+    elif report.when == "call" and CAPTURE_ALL_SCREENSHOTS:
+        # Take screenshot for ALL tests (success and failure) for debugging
+        if "login_logout" in item.fixturenames:
+            page = item.funcargs.get("login_logout")
+            if page:
+                try:
+                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    status = "PASSED" if report.passed else "FAILED"
+                    clean_test_name = clean_screenshot_filename(item.name)
+                    screenshot_name = f"{status}_{clean_test_name}_{timestamp}.png"
+                    screenshot_path = os.path.join(SCREENSHOTS_DIR, screenshot_name)
+
+                    # Ensure the path is valid before taking screenshot
+                    if not os.path.exists(SCREENSHOTS_DIR):
+                        os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+
+                    page.screenshot(path=screenshot_path, full_page=True)
+
+                    # Verify screenshot was created successfully
+                    if os.path.exists(screenshot_path) and os.path.getsize(screenshot_path) > 0:
+                        # Add screenshot to report for all tests when enabled
+                        if not hasattr(report, 'extra'):
+                            report.extra = []
+
+                        # Compute relative path from report.html location to screenshot
+                        report_dir = os.path.dirname(os.path.abspath("report.html"))
+                        relative_screenshot_path = os.path.relpath(screenshot_path, report_dir).replace("\\", "/")
+                        report.extra.append(extras.image(relative_screenshot_path, name=f"{status} Screenshot"))
+                        report.extra.append(extras.url(relative_screenshot_path, name="Open Screenshot"))
+
+                        logging.info("Screenshot captured for %s test: %s", status, screenshot_path)
+                    else:
+                        logging.error("Screenshot file was not created or is empty: %s", screenshot_path)
+                except Exception as exc:
                     logging.error("Failed to capture screenshot: %s", str(exc))
 
-    handler, stream = log_streams.get(item.nodeid, (None, None))
+    # Check for any debug screenshots that might have been created and attach them to the report
+    if report.when == "call" and report.failed:
+        # Look for debug screenshots that match the test
+        debug_screenshot_patterns = [
+            f"debug_*.png",
+            f"debug_{item.name.lower()}.png",
+            f"debug_*_{item.name.lower()}.png"
+        ]
+
+        for pattern in debug_screenshot_patterns:
+            debug_screenshots = glob.glob(os.path.join(SCREENSHOTS_DIR, pattern))
+            for debug_screenshot_path in debug_screenshots:
+                if os.path.exists(debug_screenshot_path):
+                    # Check if this screenshot was created recently (within the last minute)
+                    screenshot_time = os.path.getmtime(debug_screenshot_path)
+                    current_time = datetime.now().timestamp()
+
+                    if current_time - screenshot_time < 60:  # Within the last minute
+                        if not hasattr(report, 'extra'):
+                            report.extra = []
+
+                        screenshot_filename = os.path.basename(debug_screenshot_path)
+                        # Compute relative path from report.html location to screenshot
+                        report_dir = os.path.dirname(os.path.abspath("report.html"))
+                        relative_debug_path = os.path.relpath(debug_screenshot_path, report_dir).replace("\\", "/")
+
+                        # Add debug screenshot to report
+                        report.extra.append(extras.image(relative_debug_path, name=f"Debug Screenshot: {screenshot_filename}"))
+                        report.extra.append(extras.url(relative_debug_path, name=f"Open {screenshot_filename}"))
+
+                        logging.info("Debug screenshot attached to report: %s", debug_screenshot_path)
+
+    # Retrieve handler and stream using item id (not nodeid)
+    # This works even if the test mutated node._nodeid during execution
+    log_data = log_streams.get(id(item), (None, None, None))
+    handler, stream, original_nodeid = log_data[0], log_data[1], log_data[2] if len(log_data) == 3 else None
 
     if handler and stream:
         # Make sure logs are flushed
@@ -205,8 +308,8 @@ def pytest_runtest_makereport(item, call):
         else:
             report.description = f"<pre>{log_output.strip()}</pre>"
 
-        # Clean up references
-        log_streams.pop(item.nodeid, None)
+        # Clean up references using item id (not nodeid)
+        log_streams.pop(id(item), None)
     else:
         report.description = ""
 

--- a/tests/e2e-test/tests/conftest.py
+++ b/tests/e2e-test/tests/conftest.py
@@ -255,7 +255,10 @@ def pytest_runtest_makereport(item, call):
 
                         logging.info("Debug screenshot attached to report: %s", debug_screenshot_path)
 
-    handler, stream = log_streams.get(item.nodeid, (None, None))
+    # Retrieve handler and stream using item id (not nodeid)
+    # This works even if the test mutated node._nodeid during execution
+    log_data = log_streams.get(id(item), (None, None, None))
+    handler, stream, original_nodeid = log_data[0], log_data[1], log_data[2] if len(log_data) == 3 else None
 
     if handler and stream:
         # Make sure logs are flushed
@@ -305,8 +308,8 @@ def pytest_runtest_makereport(item, call):
         else:
             report.description = f"<pre>{log_output.strip()}</pre>"
 
-        # Clean up references
-        log_streams.pop(item.nodeid, None)
+        # Clean up references using item id (not nodeid)
+        log_streams.pop(id(item), None)
     else:
         report.description = ""
 

--- a/tests/e2e-test/tests/conftest.py
+++ b/tests/e2e-test/tests/conftest.py
@@ -168,8 +168,9 @@ def pytest_runtest_makereport(item, call):
                         if not hasattr(report, 'extra'):
                             report.extra = []
 
-                        # Use relative path for HTML report
-                        relative_screenshot_path = f"screenshots/{screenshot_name}"
+                        # Compute relative path from report.html location to screenshot
+                        report_dir = os.path.dirname(os.path.abspath("report.html"))
+                        relative_screenshot_path = os.path.relpath(screenshot_path, report_dir).replace("\\", "/")
 
                         # Add both image and link to report
                         report.extra.append(extras.image(relative_screenshot_path, name="Failure Screenshot"))
@@ -210,7 +211,9 @@ def pytest_runtest_makereport(item, call):
                         if not hasattr(report, 'extra'):
                             report.extra = []
 
-                        relative_screenshot_path = f"screenshots/{screenshot_name}"
+                        # Compute relative path from report.html location to screenshot
+                        report_dir = os.path.dirname(os.path.abspath("report.html"))
+                        relative_screenshot_path = os.path.relpath(screenshot_path, report_dir).replace("\\", "/")
                         report.extra.append(extras.image(relative_screenshot_path, name=f"{status} Screenshot"))
                         report.extra.append(extras.url(relative_screenshot_path, name="Open Screenshot"))
 
@@ -242,7 +245,9 @@ def pytest_runtest_makereport(item, call):
                             report.extra = []
 
                         screenshot_filename = os.path.basename(debug_screenshot_path)
-                        relative_debug_path = f"screenshots/{screenshot_filename}"
+                        # Compute relative path from report.html location to screenshot
+                        report_dir = os.path.dirname(os.path.abspath("report.html"))
+                        relative_debug_path = os.path.relpath(debug_screenshot_path, report_dir).replace("\\", "/")
 
                         # Add debug screenshot to report
                         report.extra.append(extras.image(relative_debug_path, name=f"Debug Screenshot: {screenshot_filename}"))

--- a/tests/e2e-test/tests/conftest.py
+++ b/tests/e2e-test/tests/conftest.py
@@ -5,17 +5,42 @@ import os
 import io
 import logging
 import atexit
+import glob
 from datetime import datetime
 
 import pytest
 from playwright.sync_api import sync_playwright
 from bs4 import BeautifulSoup
+from pytest_html import extras
 
 from config.constants import URL
 
 # Create screenshots directory if it doesn't exist
 SCREENSHOTS_DIR = os.path.join(os.path.dirname(__file__), "screenshots")
 os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+
+# Configuration for screenshot behavior
+# Capture screenshots for all tests by default, set CAPTURE_ALL_SCREENSHOTS=false to disable
+CAPTURE_ALL_SCREENSHOTS = os.getenv('CAPTURE_ALL_SCREENSHOTS', 'true').lower() == 'true'
+
+log_streams = {}
+
+
+def clean_screenshot_filename(test_name):
+    """Clean test name to create valid filename for screenshots."""
+    # Replace invalid characters for Windows filenames
+    invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*', '[', ']']
+    clean_name = test_name
+    for char in invalid_chars:
+        clean_name = clean_name.replace(char, "_")
+    # Replace spaces with underscores
+    clean_name = clean_name.replace(" ", "_")
+    # Remove duplicate underscores
+    clean_name = "_".join(filter(None, clean_name.split("_")))
+    # Truncate if too long (Windows has 255 char limit)
+    if len(clean_name) > 100:
+        clean_name = clean_name[:100]
+    return clean_name
 
 @pytest.fixture
 def subtests(request):
@@ -90,9 +115,6 @@ def login_logout():
         browser.close()
 
 
-log_streams = {}
-
-
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     """Prepare StringIO for capturing logs"""
@@ -116,44 +138,117 @@ def pytest_html_report_title(report):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """Generate test report with logs, subtest details, and screenshots on failure"""
+    """Generate test report with logs, subtest details, and screenshots"""
     outcome = yield
     report = outcome.get_result()
 
-    # Capture screenshot on failure
+    # Screenshot logic for failures
     if report.when == "call" and report.failed:
-        # Get the page fixture if it exists
+        # Take screenshot for FAILED tests
         if "login_logout" in item.fixturenames:
             page = item.funcargs.get("login_logout")
             if page:
                 try:
-                    # Generate screenshot filename with timestamp
+                    # Generate meaningful screenshot filename
                     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                    test_name = item.name.replace(" ", "_").replace("/", "_")
-                    screenshot_name = f"screenshot_{test_name}_{timestamp}.png"
+                    clean_test_name = clean_screenshot_filename(item.name)
+                    screenshot_name = f"FAILED_{clean_test_name}_{timestamp}.png"
                     screenshot_path = os.path.join(SCREENSHOTS_DIR, screenshot_name)
-                    
-                    # Take screenshot
-                    page.screenshot(path=screenshot_path)
-                    
-                    # Add screenshot link to report
-                    if not hasattr(report, 'extra'):
-                        report.extra = []
-                    
-                    # Add screenshot as a link in the Links column
-                    # Use relative path from report.html location
-                    relative_path = os.path.relpath(
-                        screenshot_path,
-                        os.path.dirname(os.path.abspath("report.html"))
-                    )
-                    
-                    # pytest-html expects this format for extras
-                    from pytest_html import extras
-                    report.extra.append(extras.url(relative_path, name='Screenshot'))
-                    
-                    logging.info("Screenshot saved: %s", screenshot_path)
-                except Exception as exc:  # pylint: disable=broad-exception-caught
+
+                    # Ensure the path is valid before taking screenshot
+                    if not os.path.exists(SCREENSHOTS_DIR):
+                        os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+
+                    # Take screenshot with error handling
+                    page.screenshot(path=screenshot_path, full_page=True)
+
+                    # Verify screenshot was created successfully
+                    if os.path.exists(screenshot_path) and os.path.getsize(screenshot_path) > 0:
+                        # Add screenshot to HTML report
+                        if not hasattr(report, 'extra'):
+                            report.extra = []
+
+                        # Use relative path for HTML report
+                        relative_screenshot_path = f"screenshots/{screenshot_name}"
+
+                        # Add both image and link to report
+                        report.extra.append(extras.image(relative_screenshot_path, name="Failure Screenshot"))
+                        report.extra.append(extras.url(relative_screenshot_path, name="Open Screenshot"))
+
+                        logging.info("Screenshot captured for FAILED test: %s", screenshot_path)
+                    else:
+                        logging.error("Screenshot file was not created or is empty: %s", screenshot_path)
+                except Exception as exc:
+                    logging.error("Failed to capture screenshot for failed test: %s", str(exc))
+            else:
+                logging.warning("Page fixture not available for screenshot in failed test: %s", item.name)
+        else:
+            logging.warning("login_logout fixture not available for screenshot in failed test: %s", item.name)
+
+    # Optional: Take screenshot for all test completion (both pass and fail) if requested
+    elif report.when == "call" and CAPTURE_ALL_SCREENSHOTS:
+        # Take screenshot for ALL tests (success and failure) for debugging
+        if "login_logout" in item.fixturenames:
+            page = item.funcargs.get("login_logout")
+            if page:
+                try:
+                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    status = "PASSED" if report.passed else "FAILED"
+                    clean_test_name = clean_screenshot_filename(item.name)
+                    screenshot_name = f"{status}_{clean_test_name}_{timestamp}.png"
+                    screenshot_path = os.path.join(SCREENSHOTS_DIR, screenshot_name)
+
+                    # Ensure the path is valid before taking screenshot
+                    if not os.path.exists(SCREENSHOTS_DIR):
+                        os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+
+                    page.screenshot(path=screenshot_path, full_page=True)
+
+                    # Verify screenshot was created successfully
+                    if os.path.exists(screenshot_path) and os.path.getsize(screenshot_path) > 0:
+                        # Add screenshot to report for all tests when enabled
+                        if not hasattr(report, 'extra'):
+                            report.extra = []
+
+                        relative_screenshot_path = f"screenshots/{screenshot_name}"
+                        report.extra.append(extras.image(relative_screenshot_path, name=f"{status} Screenshot"))
+                        report.extra.append(extras.url(relative_screenshot_path, name="Open Screenshot"))
+
+                        logging.info("Screenshot captured for %s test: %s", status, screenshot_path)
+                    else:
+                        logging.error("Screenshot file was not created or is empty: %s", screenshot_path)
+                except Exception as exc:
                     logging.error("Failed to capture screenshot: %s", str(exc))
+
+    # Check for any debug screenshots that might have been created and attach them to the report
+    if report.when == "call" and report.failed:
+        # Look for debug screenshots that match the test
+        debug_screenshot_patterns = [
+            f"debug_*.png",
+            f"debug_{item.name.lower()}.png",
+            f"debug_*_{item.name.lower()}.png"
+        ]
+
+        for pattern in debug_screenshot_patterns:
+            debug_screenshots = glob.glob(os.path.join(SCREENSHOTS_DIR, pattern))
+            for debug_screenshot_path in debug_screenshots:
+                if os.path.exists(debug_screenshot_path):
+                    # Check if this screenshot was created recently (within the last minute)
+                    screenshot_time = os.path.getmtime(debug_screenshot_path)
+                    current_time = datetime.now().timestamp()
+
+                    if current_time - screenshot_time < 60:  # Within the last minute
+                        if not hasattr(report, 'extra'):
+                            report.extra = []
+
+                        screenshot_filename = os.path.basename(debug_screenshot_path)
+                        relative_debug_path = f"screenshots/{screenshot_filename}"
+
+                        # Add debug screenshot to report
+                        report.extra.append(extras.image(relative_debug_path, name=f"Debug Screenshot: {screenshot_filename}"))
+                        report.extra.append(extras.url(relative_debug_path, name=f"Open {screenshot_filename}"))
+
+                        logging.info("Debug screenshot attached to report: %s", debug_screenshot_path)
 
     handler, stream = log_streams.get(item.nodeid, (None, None))
 

--- a/tests/e2e-test/tests/test_MACAE_Smoke_test.py
+++ b/tests/e2e-test/tests/test_MACAE_Smoke_test.py
@@ -447,6 +447,129 @@ def test_macae_v4_gp_workflow(login_logout, request):
         raise
 
 
+@pytest.mark.gp
+def test_hr_workflow_only(login_logout, request):
+    """
+    Validate HR workflow only (Steps 14-19).
+    
+    This test focuses on just the Human Resources workflow for easier debugging.
+    Note: This assumes a fresh page state.
+    
+    Steps:
+    1. Validate home page elements are visible
+    2. Select Human Resources team
+    3. Select quick task and create plan
+    4. Validate all HR agents are displayed
+    5. Approve the task plan
+    6. Send human clarification with employee details
+    7. Validate HR response
+    """
+    page = login_logout
+    biab_page = BIABPage(page)
+    
+    # Update test node ID for HTML report
+    request.node._nodeid = "(MACAE V4) HR Workflow Only - Steps 14-19"
+    
+    logger.info("=" * 80)
+    logger.info("Starting HR Workflow Test")
+    logger.info("=" * 80)
+    
+    start_time = time.time()
+    
+    try:
+        # Reload home page before starting test
+        biab_page.reload_home_page()
+        
+        # Step 1: Validate Home Page
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 1: Validating Home Page")
+        logger.info("=" * 80)
+        step1_start = time.time()
+        biab_page.validate_home_page()
+        step1_end = time.time()
+        logger.info(f"Step 1 completed in {step1_end - step1_start:.2f} seconds")
+        
+        # Step 2: Select Human Resources Team
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 2: Selecting Human Resources Team")
+        logger.info("=" * 80)
+        step2_start = time.time()
+        biab_page.select_human_resources_team()
+        step2_end = time.time()
+        logger.info(f"Step 2 completed in {step2_end - step2_start:.2f} seconds")
+        
+        # Step 3: Select Quick Task and Create Plan (HR)
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 3: Selecting Quick Task and Creating Plan (HR)")
+        logger.info("=" * 80)
+        step3_start = time.time()
+        biab_page.select_quick_task_and_create_plan()
+        step3_end = time.time()
+        logger.info(f"Step 3 completed in {step3_end - step3_start:.2f} seconds")
+        
+        # Step 4: Validate All HR Agents Visible
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 4: Validating All HR Agents Are Displayed")
+        logger.info("=" * 80)
+        step4_start = time.time()
+        biab_page.validate_hr_agents()
+        step4_end = time.time()
+        logger.info(f"Step 4 completed in {step4_end - step4_start:.2f} seconds")
+        
+        # Step 5: Approve Task Plan (HR)
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 5: Approving HR Task Plan")
+        logger.info("=" * 80)
+        step5_start = time.time()
+        biab_page.approve_task_plan()
+        step5_end = time.time()
+        logger.info(f"Step 5 completed in {step5_end - step5_start:.2f} seconds")
+        
+        # Step 6: Send Human Clarification with Employee Details
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 6: Sending Human Clarification with Employee Details")
+        logger.info("=" * 80)
+        step6_start = time.time()
+        biab_page.input_clarification_and_send(HR_CLARIFICATION_TEXT)
+        step6_end = time.time()
+        logger.info(f"Step 6 completed in {step6_end - step6_start:.2f} seconds")
+        
+        # Step 7: Validate HR Response
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 7: Validating HR Response")
+        logger.info("=" * 80)
+        step7_start = time.time()
+        biab_page.validate_hr_response()
+        step7_end = time.time()
+        logger.info(f"Step 7 completed in {step7_end - step7_start:.2f} seconds")
+        
+        # Test completed successfully
+        end_time = time.time()
+        total_duration = end_time - start_time
+        
+        logger.info("\n" + "=" * 80)
+        logger.info("✓ HR Workflow Test PASSED")
+        logger.info("=" * 80)
+        logger.info(f"Total execution time: {total_duration:.2f} seconds")
+        logger.info("=" * 80)
+        
+        # Attach execution time to pytest report
+        request.node._report_sections.append(
+            ("call", "log", f"Total execution time: {total_duration:.2f}s")
+        )
+        
+    except Exception as e:
+        end_time = time.time()
+        total_duration = end_time - start_time
+        logger.error("\n" + "=" * 80)
+        logger.error("TEST EXECUTION FAILED")
+        logger.error("=" * 80)
+        logger.error(f"Error: {str(e)}")
+        logger.error(f"Execution time before failure: {total_duration:.2f}s")
+        logger.error("=" * 80)
+        raise
+
+
 def test_validate_source_text_not_visible(login_logout, request):
     """
     Validate that source text is not visible after retail customer response.
@@ -640,7 +763,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_retail_customer_success_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -661,7 +784,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_product_marketing_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -682,7 +805,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_human_resources_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -703,7 +826,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_rfp_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -724,7 +847,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_contract_compliance_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -1396,7 +1519,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step2_start = time.time()
         
         biab_page.select_human_resources_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step2_end = time.time()
@@ -1409,7 +1532,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step3_start = time.time()
         
         biab_page.select_product_marketing_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step3_end = time.time()
@@ -1422,7 +1545,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step4_start = time.time()
         
         biab_page.select_retail_customer_success_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step4_end = time.time()
@@ -1435,7 +1558,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step5_start = time.time()
         
         biab_page.select_rfp_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step5_end = time.time()
@@ -1448,7 +1571,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step6_start = time.time()
         
         biab_page.select_contract_compliance_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step6_end = time.time()
@@ -1552,7 +1675,7 @@ def test_chat_input_validation(login_logout, request):
         
         # Create a long query (>5000 characters)
         long_query = "a" * 5001
-        biab_page.input_RAI_PROMPT_and_send(long_query)
+        biab_page.input_rai_prompt_and_send(long_query)
         biab_page.validate_rai_error_message()
         
         step5_end = time.time()

--- a/tests/e2e-test/tests/test_MACAE_Smoke_test.py
+++ b/tests/e2e-test/tests/test_MACAE_Smoke_test.py
@@ -447,6 +447,129 @@ def test_macae_v4_gp_workflow(login_logout, request):
         raise
 
 
+@pytest.mark.gp
+def test_hr_workflow_only(login_logout, request):
+    """
+    Validate HR workflow only (Steps 14-19).
+    
+    This test focuses on just the Human Resources workflow for easier debugging.
+    Note: This assumes a fresh page state.
+    
+    Steps:
+    1. Validate home page elements are visible
+    2. Select Human Resources team
+    3. Select quick task and create plan
+    4. Validate all HR agents are displayed
+    5. Approve the task plan
+    6. Send human clarification with employee details
+    7. Validate HR response
+    """
+    page = login_logout
+    biab_page = BIABPage(page)
+    
+    # Update test node ID for HTML report
+    request.node._nodeid = "(MACAE V4) HR Workflow Only - Steps 14-19"
+    
+    logger.info("=" * 80)
+    logger.info("Starting HR Workflow Test")
+    logger.info("=" * 80)
+    
+    start_time = time.time()
+    
+    try:
+        # Reload home page before starting test
+        biab_page.reload_home_page()
+        
+        # Step 1: Validate Home Page
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 1: Validating Home Page")
+        logger.info("=" * 80)
+        step1_start = time.time()
+        biab_page.validate_home_page()
+        step1_end = time.time()
+        logger.info(f"Step 1 completed in {step1_end - step1_start:.2f} seconds")
+        
+        # Step 2: Select Human Resources Team
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 2: Selecting Human Resources Team")
+        logger.info("=" * 80)
+        step2_start = time.time()
+        biab_page.select_human_resources_team()
+        step2_end = time.time()
+        logger.info(f"Step 2 completed in {step2_end - step2_start:.2f} seconds")
+        
+        # Step 3: Select Quick Task and Create Plan (HR)
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 3: Selecting Quick Task and Creating Plan (HR)")
+        logger.info("=" * 80)
+        step3_start = time.time()
+        biab_page.select_quick_task_and_create_plan()
+        step3_end = time.time()
+        logger.info(f"Step 3 completed in {step3_end - step3_start:.2f} seconds")
+        
+        # Step 4: Validate All HR Agents Visible
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 4: Validating All HR Agents Are Displayed")
+        logger.info("=" * 80)
+        step4_start = time.time()
+        biab_page.validate_hr_agents()
+        step4_end = time.time()
+        logger.info(f"Step 4 completed in {step4_end - step4_start:.2f} seconds")
+        
+        # Step 5: Approve Task Plan (HR)
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 5: Approving HR Task Plan")
+        logger.info("=" * 80)
+        step5_start = time.time()
+        biab_page.approve_task_plan()
+        step5_end = time.time()
+        logger.info(f"Step 5 completed in {step5_end - step5_start:.2f} seconds")
+        
+        # Step 6: Send Human Clarification with Employee Details
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 6: Sending Human Clarification with Employee Details")
+        logger.info("=" * 80)
+        step6_start = time.time()
+        biab_page.input_clarification_and_send(HR_CLARIFICATION_TEXT)
+        step6_end = time.time()
+        logger.info(f"Step 6 completed in {step6_end - step6_start:.2f} seconds")
+        
+        # Step 7: Validate HR Response
+        logger.info("\n" + "=" * 80)
+        logger.info("STEP 7: Validating HR Response")
+        logger.info("=" * 80)
+        step7_start = time.time()
+        biab_page.validate_hr_response()
+        step7_end = time.time()
+        logger.info(f"Step 7 completed in {step7_end - step7_start:.2f} seconds")
+        
+        # Test completed successfully
+        end_time = time.time()
+        total_duration = end_time - start_time
+        
+        logger.info("\n" + "=" * 80)
+        logger.info("✓ HR Workflow Test PASSED")
+        logger.info("=" * 80)
+        logger.info(f"Total execution time: {total_duration:.2f} seconds")
+        logger.info("=" * 80)
+        
+        # Attach execution time to pytest report
+        request.node._report_sections.append(
+            ("call", "log", f"Total execution time: {total_duration:.2f}s")
+        )
+        
+    except Exception as e:
+        end_time = time.time()
+        total_duration = end_time - start_time
+        logger.error("\n" + "=" * 80)
+        logger.error("TEST EXECUTION FAILED")
+        logger.error("=" * 80)
+        logger.error(f"Error: {str(e)}")
+        logger.error(f"Execution time before failure: {total_duration:.2f}s")
+        logger.error("=" * 80)
+        raise
+
+
 def test_validate_source_text_not_visible(login_logout, request):
     """
     Validate that source text is not visible after retail customer response.
@@ -640,7 +763,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_retail_customer_success_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -661,7 +784,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_product_marketing_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -682,7 +805,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_human_resources_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -703,7 +826,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_rfp_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -724,7 +847,7 @@ def test_rai_validation_unable_to_create_plan(login_logout, request):
         biab_page.select_contract_compliance_team()
         
         logger.info(f"Entering RAI prompt: {RAI_PROMPT}")
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         
         logger.info("Validating 'Unable to create plan' message is visible...")
         biab_page.validate_rai_error_message()
@@ -1396,7 +1519,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step2_start = time.time()
         
         biab_page.select_human_resources_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step2_end = time.time()
@@ -1409,7 +1532,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step3_start = time.time()
         
         biab_page.select_product_marketing_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step3_end = time.time()
@@ -1422,7 +1545,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step4_start = time.time()
         
         biab_page.select_retail_customer_success_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step4_end = time.time()
@@ -1435,7 +1558,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step5_start = time.time()
         
         biab_page.select_rfp_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step5_end = time.time()
@@ -1448,7 +1571,7 @@ def test_rai_prompts_all_teams(login_logout, request):
         step6_start = time.time()
         
         biab_page.select_contract_compliance_team()
-        biab_page.input_RAI_PROMPT_and_send(RAI_PROMPT)
+        biab_page.input_rai_prompt_and_send(RAI_PROMPT)
         biab_page.validate_rai_error_message()
         
         step6_end = time.time()
@@ -1552,11 +1675,16 @@ def test_chat_input_validation(login_logout, request):
         
         # Create a long query (>5000 characters)
         long_query = "a" * 5001
-        biab_page.input_RAI_PROMPT_and_send(long_query)
-        biab_page.validate_rai_error_message()
+        biab_page.input_rai_prompt_and_send(long_query)
+        biab_page.validate_input_validation_error()
         
         step5_end = time.time()
         logger.info(f"Step 5 completed in {step5_end - step5_start:.2f} seconds")
+        
+        # Reload page to clear error state before testing valid query
+        logger.info("Reloading page to clear error state...")
+        biab_page.reload_home_page()
+        biab_page.select_human_resources_team()
         
         # Step 6: Test valid short query
         logger.info("\n" + "=" * 80)

--- a/tests/e2e-test/tests/test_MACAE_Smoke_test.py
+++ b/tests/e2e-test/tests/test_MACAE_Smoke_test.py
@@ -1676,10 +1676,15 @@ def test_chat_input_validation(login_logout, request):
         # Create a long query (>5000 characters)
         long_query = "a" * 5001
         biab_page.input_rai_prompt_and_send(long_query)
-        biab_page.validate_rai_error_message()
+        biab_page.validate_input_validation_error()
         
         step5_end = time.time()
         logger.info(f"Step 5 completed in {step5_end - step5_start:.2f} seconds")
+        
+        # Reload page to clear error state before testing valid query
+        logger.info("Reloading page to clear error state...")
+        biab_page.reload_home_page()
+        biab_page.select_human_resources_team()
         
         # Step 6: Test valid short query
         logger.info("\n" + "=" * 80)


### PR DESCRIPTION
## Purpose
This pull request introduces important bug fixes and enhancements to both the backend orchestration logic and the end-to-end (E2E) test automation for the multi-agent planner system. The main focus is on improving workflow reliability by ensuring all agents respond before marking a request as satisfied, and making E2E tests more robust and informative by synchronizing with UI states and validating response content more thoroughly.

**Backend orchestration improvements:**

* Added a guard in `HumanApprovalManager` to prevent the workflow from being prematurely marked as satisfied before all planned agents (excluding proxies/managers) have responded. This addresses a bug where the orchestrator could terminate after a single agent's response. (`src/backend/v4/orchestration/human_approval_manager.py`) [[1]](diffhunk://#diff-7e4b9471972ac98ae1a6aad5952ebd050013f9c5677aa58ee16553ec796c1bcaR224-R225) [[2]](diffhunk://#diff-7e4b9471972ac98ae1a6aad5952ebd050013f9c5677aa58ee16553ec796c1bcaL259-R319)

**E2E test automation enhancements:**

* Improved synchronization in test validations by waiting for the "AI Thinking Process" indicator to disappear before checking for response content, reducing flakiness in tests. (`tests/e2e-test/pages/HomePage.py`) [[1]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfR37) [[2]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfR516-R559) [[3]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfL549-R626) [[4]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfL573-R687) [[5]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfL597-R792)
* Enhanced content validation for retail, product marketing, HR, RFP, and contract compliance responses by checking for expected patterns and providing more informative logging and warnings if content is missing. (`tests/e2e-test/pages/HomePage.py`) [[1]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfR516-R559) [[2]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfL549-R626) [[3]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfL573-R687) [[4]](diffhunk://#diff-dce6cd5e9bde969d49a99086cb2ea19215916279b4ac741fe2d154d1ebea77bfL597-R792)
* Improved handling of clarification input in tests by explicitly waiting for the input to become enabled before interacting with it. (`tests/e2e-test/pages/HomePage.py`)

**Documentation update:**

* Updated deployment instructions to include a note about disabling provision preflight checks with the latest `azd` version. (`docs/DeploymentGuide.md`)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->