### PR TITLE
fix: Customize the ledger to not to skip agents

### DIFF
--- a/src/backend/v4/orchestration/human_approval_manager.py
+++ b/src/backend/v4/orchestration/human_approval_manager.py
@@ -221,6 +221,8 @@ DO NOT EVER OFFER TO HELP FURTHER IN THE FINAL ANSWER! Just provide the final an
     async def create_progress_ledger(self, magentic_context: MagenticContext):
         """
         Check for max rounds exceeded and send final message if so, else defer to base.
+        After base evaluation, prevent premature satisfaction by ensuring all planned
+        agents have responded before allowing is_request_satisfied=True.
 
         Returns:
             Progress ledger object (type depends on agent_framework version)
@@ -256,7 +258,65 @@ DO NOT EVER OFFER TO HELP FURTHER IN THE FINAL ANSWER! Just provide the final an
             return ledger
 
         # Delegate to base for normal progress ledger creation
-        return await super().create_progress_ledger(magentic_context)
+        ledger = await super().create_progress_ledger(magentic_context)
+
+        # --- Premature satisfaction guard ---
+        # If the LLM says the request is satisfied, verify that all planned
+        # (non-proxy, non-manager) agents have actually responded before allowing
+        # the workflow to terminate.  This addresses the bug where the orchestrator
+        # marks satisfied=True after a single comprehensive agent response.
+        if ledger.is_request_satisfied.answer:
+            uncalled = self._get_uncalled_agents(magentic_context)
+            if uncalled:
+                next_agent = uncalled[0]
+                logger.info(
+                    "Progress ledger marked satisfied but %d agent(s) have not responded yet: %s. "
+                    "Overriding to continue with '%s'.",
+                    len(uncalled),
+                    uncalled,
+                    next_agent,
+                )
+                ledger.is_request_satisfied.answer = False
+                ledger.is_request_satisfied.reason = (
+                    f"Not all agents have responded yet. Waiting for: {', '.join(uncalled)}"
+                )
+                ledger.is_progress_being_made.answer = True
+                ledger.is_progress_being_made.reason = "Continuing to consult remaining agents"
+                ledger.next_speaker.answer = next_agent
+                ledger.next_speaker.reason = f"{next_agent} has not yet been consulted"
+                # Always override instruction with task-relevant prompt so that
+                # data agents (Azure AI Search, RAG) execute meaningful queries
+                # instead of receiving a stale finalization instruction.
+                task_text = getattr(magentic_context.task, "text", str(magentic_context.task))
+                ledger.instruction_or_question.answer = (
+                    f"Using your available tools and data sources, provide your response for the following task: {task_text}"
+                )
+                ledger.instruction_or_question.reason = (
+                    f"Routing to {next_agent} who has not yet contributed"
+                )
+
+        return ledger
+
+    @staticmethod
+    def _get_uncalled_agents(magentic_context: MagenticContext) -> list[str]:
+        """Return agent names from participant_descriptions that have not yet
+        authored a message in the chat_history (excluding ProxyAgent and the
+        MagenticManager)."""
+        skip_names = {"ProxyAgent", "MagenticManager", "magentic_manager"}
+
+        all_agents = [
+            name for name in magentic_context.participant_descriptions
+            if name not in skip_names
+        ]
+
+        # Collect author names that appear in chat_history
+        responded = set()
+        for msg in magentic_context.chat_history:
+            author = getattr(msg, "author_name", None)
+            if author:
+                responded.add(author)
+
+        return [name for name in all_agents if name not in responded]
 
     async def _wait_for_user_approval(
         self, m_plan_id: Optional[str] = None


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request addresses a bug in the human approval orchestration logic where the workflow could be prematurely marked as satisfied after a single agent's response, even if other planned agents had not yet contributed. The main change introduces a safeguard to ensure all relevant agents have responded before the request can be considered satisfied.

**Bug fix: Preventing premature workflow satisfaction**

* Added a "premature satisfaction guard" in `create_progress_ledger` to check that all planned (non-proxy, non-manager) agents have responded before allowing `is_request_satisfied` to be set to `True`. If not all agents have responded, the ledger is overridden to continue the workflow, and the next uncalled agent is prompted.
* Introduced a helper method `_get_uncalled_agents` to determine which agents have not yet authored a message, excluding proxy and manager agents.
* Updated the method docstring to document the new logic that prevents premature satisfaction.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->