### PR TITLE
refactor: Refactor JSON error handling and remove allowedFqdnList

### DIFF
--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -91,25 +91,6 @@
     },
     "MCPContainerRegistryHostname": {
       "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT}"
-    },
-    "allowedFqdnList": {
-      "value": [
-        "mcr.microsoft.com",
-        "openai.azure.com",
-        "cognitiveservices.azure.com",
-        "login.microsoftonline.com",
-        "management.azure.com",
-        "aiinfra.azure.com",
-        "aiinfra.azure.net",
-        "aiinfra.azureedge.net",
-        "blob.core.windows.net",
-        "database.windows.net",
-        "vault.azure.net",
-        "monitoring.azure.com",
-        "dc.services.visualstudio.com",
-        "azconfig.io",
-        "azconfig.azure.net"
-      ]
     }
   }
 }

--- a/infra/scripts/validate_bicep_params.py
+++ b/infra/scripts/validate_bicep_params.py
@@ -108,7 +108,9 @@ def parse_parameters_env_vars(json_path: Path) -> dict[str, list[str]]:
         data = json.loads(sanitized)
         params = data.get("parameters", {})
     except json.JSONDecodeError:
-        pass
+        # Malformed JSON cannot be reliably parsed for env-var extraction;
+        # return an empty mapping so the caller can still proceed.
+        return {}
 
     # Walk each top-level parameter and scan its entire serialized value
     # for ${VAR} references from the original text.


### PR DESCRIPTION
## Purpose
This pull request makes two focused changes related to infrastructure parameter handling and error resilience in scripts. The main updates are the removal of the `allowedFqdnList` parameter from the infrastructure parameters file and improved error handling for malformed JSON in the parameter validation script.

Parameter and configuration updates:

* Removed the `allowedFqdnList` parameter (and its associated list of allowed FQDNs) from `infra/main.waf.parameters.json`.

Script robustness improvements:

* Updated `parse_parameters_env_vars` in `infra/scripts/validate_bicep_params.py` to return an empty mapping if the parameters JSON is malformed, instead of failing silently. This allows the caller to continue processing even if the input is not valid JSON.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No