### PR TITLE
fix: Resolve FlagMustBeSetToRestore telemetry error

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -12,9 +12,12 @@ metadata description = '''This module contains the resources required to deploy 
 @maxLength(16)
 param solutionName string = 'macae'
 
+@description('Optional. Deployment timestamp used to generate unique resource names per deployment.')
+param deploymentTime string = utcNow()
+
 @maxLength(5)
-@description('Optional. A unique text value for the solution. This is used to ensure resource names are unique for global resources. Defaults to a 5-character substring of the unique string generated from the subscription ID, resource group name, and solution name.')
-param solutionUniqueText string = take(uniqueString(subscription().id, resourceGroup().name, solutionName), 5)
+@description('Optional. A unique text value for the solution. This is used to ensure resource names are unique for global resources. Defaults to a 5-character substring of the unique string generated from the subscription ID, resource group name, solution name, and deployment time.')
+param solutionUniqueText string = take(uniqueString(subscription().id, resourceGroup().name, solutionName, deploymentTime), 5)
 
 @metadata({ azd: { type: 'location' } })
 @description('Required. Azure region for all services. Regions are restricted to guarantee compatibility with paired regions and replica locations for data redundancy and failover scenarios based on articles [Azure regions list](https://learn.microsoft.com/azure/reliability/regions-list) and [Azure Database for MySQL Flexible Server - Azure Regions](https://learn.microsoft.com/azure/mysql/flexible-server/overview#azure-regions).')


### PR DESCRIPTION
## Purpose
This pull request updates the way unique resource names are generated in the `infra/main.bicep` deployment template by including a deployment timestamp. This change helps ensure that resource names are unique across different deployments, even if the other parameters are the same.

Resource naming improvements:

* Added a new `deploymentTime` parameter (defaulting to the current UTC time) to help generate unique resource names for each deployment.
* Updated the `solutionUniqueText` parameter to include `deploymentTime` in its unique string generation, ensuring that resource names are unique for each deployment instance.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->