### PR TITLE
feat: Add pytest coverage comment to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ on:
       - demo
       - hotfix
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -51,8 +56,20 @@ jobs:
       - name: Run tests with coverage
         if: env.skip_tests == 'false'
         run: |
-          pytest --cov=. --cov-report=term-missing --cov-report=xml --ignore=tests/e2e-test/tests
+          pytest --cov=. --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml --ignore=tests/e2e-test/tests
           
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          env.skip_tests == 'false'
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: pytest.xml
+          report-only-changed-files: true
+
       - name: Skip coverage report if no tests
         if: env.skip_tests == 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,14 @@ jobs:
       - name: Run tests with coverage
         if: env.skip_tests == 'false'
         run: |
-          pytest --cov=src/backend --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml --ignore=tests/e2e-test/tests --omit="*/tests/*"
+          cat > .coveragerc << 'EOF'
+          [run]
+          source = src/backend
+          omit =
+              */tests/*
+              */test_*
+          EOF
+          pytest --cov --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml --ignore=tests/e2e-test/tests
 
       - name: Pytest Coverage Comment
         if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - demo
       - hotfix
   pull_request:
     types:
@@ -15,9 +14,7 @@ on:
       - synchronize
     branches:
       - main
-      - main
       - dev
-      - demo
       - hotfix
 
 permissions:
@@ -53,11 +50,12 @@ jobs:
             echo "Test files found, running tests."
             echo "skip_tests=false" >> $GITHUB_ENV
           fi
+
       - name: Run tests with coverage
         if: env.skip_tests == 'false'
         run: |
-          pytest --cov=. --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml --ignore=tests/e2e-test/tests
-          
+          pytest --cov=src/backend --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml --ignore=tests/e2e-test/tests --omit="*/tests/*"
+
       - name: Pytest Coverage Comment
         if: |
           always() &&


### PR DESCRIPTION
Add MishaKav/pytest-coverage-comment action to post code coverage summary as a PR comment. Changes include:
- Add permissions block with pull-requests: write
- Add --junitxml=pytest.xml flag for test summary
- Add coverage comment step with per-file breakdown

## Purpose

This pull request updates the GitHub Actions workflow for testing to improve permissions management and enhance test coverage reporting. The most important changes are grouped below:

**Workflow Permissions:**

* Added explicit `permissions` to the workflow, granting read access to `contents` and `actions`, and write access to `pull-requests` to enable automated comments and improve security.

**Test Coverage Reporting Enhancements:**

* Modified the pytest command to generate a JUnit XML report (`--junitxml=pytest.xml`) in addition to the existing coverage reports, enabling richer test result outputs.
* Integrated the `MishaKav/pytest-coverage-comment` GitHub Action to automatically post coverage summaries as comments on pull requests, but only for non-fork PRs where tests are not skipped. This uses the generated `coverage.xml` and `pytest.xml` files and reports only on changed files.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

