### PR TITLE
feat: Add pytest coverage comment to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - demo-v4
       - dev-v4
     paths:
       - 'src/backend/**/*.py'
@@ -22,6 +23,7 @@ on:
       - synchronize
     branches:
       - main
+      - demo-v4
       - dev-v4
     paths:
       - 'src/backend/**/*.py'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - demo-v4
       - dev-v4
     paths:
       - 'src/backend/**/*.py'
@@ -23,7 +22,6 @@ on:
       - synchronize
     branches:
       - main
-      - demo-v4
       - dev-v4
     paths:
       - 'src/backend/**/*.py'
@@ -34,6 +32,11 @@ on:
       - 'src/backend/requirements.txt'
       - 'src/**/pyproject.toml'
       - '.github/workflows/test.yml'
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
 
 jobs:
   test:
@@ -71,9 +74,9 @@ jobs:
         run: |
           # Run test_app.py first (isolation required)
           python -m pytest src/tests/backend/test_app.py --cov=src/backend --cov-config=.coveragerc -q
-          
+
           # Run remaining backend tests with coverage append
-          python -m pytest src/tests/backend --cov=src/backend --cov-append --cov-report=term --cov-report=xml --cov-config=.coveragerc --ignore=src/tests/backend/test_app.py
+          python -m pytest src/tests/backend --cov=src/backend --cov-append --cov-report=term --cov-report=xml --junitxml=pytest.xml --cov-config=.coveragerc --ignore=src/tests/backend/test_app.py
 
       - name: Check coverage threshold
         if: env.skip_tests == 'false'
@@ -90,6 +93,18 @@ jobs:
             echo "::error::coverage.xml not found"
             exit 1
           fi
+
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          env.skip_tests == 'false'
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: pytest.xml
+          report-only-changed-files: true
 
       - name: Skip coverage report if no tests
         if: env.skip_tests == 'true'


### PR DESCRIPTION
## Summary
Adds automated code coverage reporting as PR comments using [MishaKav/pytest-coverage-comment](https://github.com/MishaKav/pytest-coverage-comment).

## Changes
- **Added \\permissions\\ block** — \\pull-requests: write\\ needed for comment posting
- **Added \\--junitxml=pytest.xml\\** — generates test summary for the comment
- **Added MishaKav/pytest-coverage-comment step** — posts coverage report and test results as PR comment (pinned by SHA per Microsoft security standards)
- **Removed \\demo-v4\\ from target branches**

## How it works
After tests run, a comment is posted on the PR showing:
- Overall coverage percentage with badge
- Per-file coverage for changed files only
- Test pass/fail/skip summary

The comment step uses \\lways()\\ to run even if tests fail, and is skipped for fork PRs (read-only tokens).

## No impact on existing behavior
- Existing test execution, coverage threshold (80%), and CI behavior are unchanged
- The coverage comment is additive — it only adds visibility for reviewers