### PR TITLE
docs: Add Bicep CLI (v0.33.0+) to local deployment prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Follow the quick deploy steps on the deployment guide to deploy this solution to
 
 > **Note:** This solution accelerator requires **Azure Developer CLI (azd) version 1.18.0 or higher**. Please ensure you have the latest version installed before proceeding with deployment. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 
-> **Note:** This solution accelerator also requires **Bicep CLI version 0.33.0 or higher** for compiling infrastructure templates. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install).
+> **Note:** If deploying from a **local environment** (Option D in the deployment guide), this solution accelerator requires **Bicep CLI version 0.33.0 or higher** to compile infrastructure templates. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install).
 
 [Click here to launch the deployment guide](./docs/DeploymentGuide.md)
 <br/><br/>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Follow the quick deploy steps on the deployment guide to deploy this solution to
 
 > **Note:** This solution accelerator requires **Azure Developer CLI (azd) version 1.18.0 or higher**. Please ensure you have the latest version installed before proceeding with deployment. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 
+> **Note:** This solution accelerator also requires **Bicep CLI version 0.33.0 or higher** for compiling infrastructure templates. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install).
+
 [Click here to launch the deployment guide](./docs/DeploymentGuide.md)
 <br/><br/>
 

--- a/docs/AVMPostDeploymentGuide.md
+++ b/docs/AVMPostDeploymentGuide.md
@@ -29,6 +29,7 @@ Before starting the post-deployment process, ensure you have the following:
 3. **[Python](https://www.python.org/downloads/)** <small>(v4.9+ recommended)</small> - Required for data processing scripts
 
 4. **[Git](https://git-scm.com/downloads/)** - Version control system for cloning the repository
+5. **[Bicep CLI](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install)** <small>(v0.33.0+)</small> - Required for compiling infrastructure templates
 
 ### Azure Requirements
 

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -153,6 +153,7 @@ Select one of the following options to deploy the Multi Agent Custom Automation 
 **Required Tools:**
 - [PowerShell 7.0+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 
 - [Azure Developer CLI (azd) 1.18.0+](https://aka.ms/install-azd)
+- [Bicep CLI 0.33.0+](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install)
 - [Python 3.9+](https://www.python.org/downloads/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [Git](https://git-scm.com/downloads)

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -153,7 +153,7 @@ Select one of the following options to deploy the Multi Agent Custom Automation 
 **Required Tools:**
 - [PowerShell 7.0+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 
 - [Azure Developer CLI (azd) 1.18.0+](https://aka.ms/install-azd)
-- [Bicep CLI 0.33.0+](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install)
+- [Bicep CLI 0.33.0+](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) - command-line Bicep compiler required for deployments (separate from the VS Code Bicep extension)
 - [Python 3.9+](https://www.python.org/downloads/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [Git](https://git-scm.com/downloads)


### PR DESCRIPTION
## Summary

This PR adds the **Bicep CLI** (`v0.33.0+`) as a prerequisite to the local deployment guide of this Generic Solution Accelerator.

The infrastructure-as-code templates in this repository (under `infra/`) require a recent version of the Bicep CLI to compile and deploy successfully via `azd up` / `az deployment`. Without the minimum supported version, users running the deployment locally encounter cryptic compilation errors due to unsupported syntax/features in older Bicep releases.

## Changes

- Added a Bicep CLI (v0.33.0+) entry to the prerequisites list of the local deployment guide, following the **exact format and style** of the existing prerequisite entries (azd, Python, Node.js, etc.) in this repo.

## Why

- Aligns the local deployment guide with the actual minimum Bicep version required by the Bicep templates in this repository.
- Prevents first-run failures for new users provisioning the accelerator from a fresh local environment.
- Brings this accelerator in line with the standard prerequisite set being rolled out across all CSA Generic Solution Accelerators (GSAs).

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Verified the Markdown renders correctly on GitHub (entry appears in the prerequisites list, link resolves to the official Microsoft Learn install page).
- [x] Confirmed the change is scoped to documentation only — no code, infrastructure, or configuration paths are modified.

## Checklist

- [x] My change follows the existing documentation style and formatting of the repository.
- [x] I have performed a self-review of my changes.
- [x] No new warnings, broken links, or formatting issues are introduced.
- [x] No code, configuration, or behavior changes are included in this PR (docs-only).

## Related Work Item

- AB#42634 — `[ALL GSA's] - Add bicep version to the local deployment guide`
