### PR TITLE
chore: Add tags to prevent SFI W18 Policy violation

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1139,6 +1139,10 @@ module containerAppEnvironment 'br/public:avm/res/app/managed-environment:0.13.1
     tags: {
       ...resourceGroup().tags
       ...tags
+      TemplateName: 'MACAE'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+      CreatedBy: createdBy
+      DeploymentName: deployment().name
     }
     enableTelemetry: enableTelemetry
     // WAF aligned configuration for Private Networking

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1138,11 +1138,9 @@ module containerAppEnvironment 'br/public:avm/res/app/managed-environment:0.13.1
     location: location
     tags: {
       ...resourceGroup().tags
+      ...existingTags
+      ...allTags
       ...tags
-      TemplateName: 'MACAE'
-      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
-      CreatedBy: createdBy
-      DeploymentName: deployment().name
     }
     enableTelemetry: enableTelemetry
     // WAF aligned configuration for Private Networking

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1136,7 +1136,10 @@ module containerAppEnvironment 'br/public:avm/res/app/managed-environment:0.13.1
   params: {
     name: containerAppEnvironmentResourceName
     location: location
-    tags: tags
+    tags: {
+      ...resourceGroup().tags
+      ...tags
+    }
     enableTelemetry: enableTelemetry
     // WAF aligned configuration for Private Networking
     publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "16253002153134395573"
+      "templateHash": "15501943451693952090"
     },
     "name": "Multi-Agent Custom Automation Engine",
     "description": "This module contains the resources required to deploy the [Multi-Agent Custom Automation Engine solution accelerator](https://github.com/microsoft/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator) for both Sandbox environments and WAF aligned environments.\r\n\r\n> **Note:** This module is not intended for broad, generic use, as it was designed by the Commercial Solution Areas CTO team, as a Microsoft Solution Accelerator. Feature requests and bug fix requests are welcome if they support the needs of this organization but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case. This module will likely be updated to leverage AVM resource modules in the future. This may result in breaking changes in upcoming versions when these features are implemented.\r\n"
@@ -34109,7 +34109,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags')))]"
+            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'MACAE', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name)))]"
           },
           "enableTelemetry": {
             "value": "[parameters('enableTelemetry')]"

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "15501943451693952090"
+      "templateHash": "1714347084428380969"
     },
     "name": "Multi-Agent Custom Automation Engine",
     "description": "This module contains the resources required to deploy the [Multi-Agent Custom Automation Engine solution accelerator](https://github.com/microsoft/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator) for both Sandbox environments and WAF aligned environments.\r\n\r\n> **Note:** This module is not intended for broad, generic use, as it was designed by the Commercial Solution Areas CTO team, as a Microsoft Solution Accelerator. Feature requests and bug fix requests are welcome if they support the needs of this organization but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case. This module will likely be updated to leverage AVM resource modules in the future. This may result in breaking changes in upcoming versions when these features are implemented.\r\n"
@@ -27973,9 +27973,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "virtualNetwork"
       ]
     },
@@ -34109,7 +34109,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'MACAE', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name)))]"
+            "value": "[shallowMerge(createArray(resourceGroup().tags, variables('existingTags'), variables('allTags'), parameters('tags')))]"
           },
           "enableTelemetry": {
             "value": "[parameters('enableTelemetry')]"

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "8490920419623942773"
+      "version": "0.39.26.7824",
+      "templateHash": "6973968965982796675"
     },
     "name": "Multi-Agent Custom Automation Engine",
     "description": "This module contains the resources required to deploy the [Multi-Agent Custom Automation Engine solution accelerator](https://github.com/microsoft/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator) for both Sandbox environments and WAF aligned environments.\r\n\r\n> **Note:** This module is not intended for broad, generic use, as it was designed by the Commercial Solution Areas CTO team, as a Microsoft Solution Accelerator. Feature requests and bug fix requests are welcome if they support the needs of this organization but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case. This module will likely be updated to leverage AVM resource modules in the future. This may result in breaking changes in upcoming versions when these features are implemented.\r\n"
@@ -4991,8 +4991,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "4286500745908716598"
+              "version": "0.39.26.7824",
+              "templateHash": "16466396517695720401"
             }
           },
           "definitions": {
@@ -24308,8 +24308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "6570260143045999127"
+              "version": "0.39.26.7824",
+              "templateHash": "3729960794136576463"
             }
           },
           "definitions": {
@@ -24616,7 +24616,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -27973,9 +27973,9 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "virtualNetwork"
       ]
     },
@@ -28012,8 +28012,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "14513113443903512301"
+              "version": "0.39.26.7824",
+              "templateHash": "2511165232243944989"
             }
           },
           "parameters": {
@@ -34109,7 +34109,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": "[parameters('tags')]"
+            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags')))]"
           },
           "enableTelemetry": {
             "value": "[parameters('enableTelemetry')]"
@@ -42561,8 +42561,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15053339789155096730"
+              "version": "0.39.26.7824",
+              "templateHash": "17255929531929846207"
             }
           },
           "definitions": {
@@ -43518,7 +43518,7 @@
               },
               "type": "Microsoft.Insights/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
-              "scope": "[resourceId('Microsoft.Web/sites', parameters('name'))]",
+              "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
               "properties": {
                 "copy": [
@@ -43593,8 +43593,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "16493651611122310009"
+                      "version": "0.39.26.7824",
+                      "templateHash": "5308269420307571977"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -54840,8 +54840,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "4859654437121510695"
+              "version": "0.39.26.7824",
+              "templateHash": "5805872877074593071"
             }
           },
           "parameters": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.39.26.7824",
-      "templateHash": "6973968965982796675"
+      "version": "0.43.8.12551",
+      "templateHash": "16253002153134395573"
     },
     "name": "Multi-Agent Custom Automation Engine",
     "description": "This module contains the resources required to deploy the [Multi-Agent Custom Automation Engine solution accelerator](https://github.com/microsoft/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator) for both Sandbox environments and WAF aligned environments.\r\n\r\n> **Note:** This module is not intended for broad, generic use, as it was designed by the Commercial Solution Areas CTO team, as a Microsoft Solution Accelerator. Feature requests and bug fix requests are welcome if they support the needs of this organization but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case. This module will likely be updated to leverage AVM resource modules in the future. This may result in breaking changes in upcoming versions when these features are implemented.\r\n"
@@ -4991,8 +4991,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "16466396517695720401"
+              "version": "0.43.8.12551",
+              "templateHash": "9540091515555271756"
             }
           },
           "definitions": {
@@ -24308,8 +24308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "3729960794136576463"
+              "version": "0.43.8.12551",
+              "templateHash": "7866379492866507946"
             }
           },
           "definitions": {
@@ -24616,7 +24616,7 @@
               },
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
               "properties": {
                 "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -28012,8 +28012,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "2511165232243944989"
+              "version": "0.43.8.12551",
+              "templateHash": "2868048678223903575"
             }
           },
           "parameters": {
@@ -42561,8 +42561,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "17255929531929846207"
+              "version": "0.43.8.12551",
+              "templateHash": "18345308984648474640"
             }
           },
           "definitions": {
@@ -43518,7 +43518,7 @@
               },
               "type": "Microsoft.Insights/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
-              "scope": "[format('Microsoft.Web/sites/{0}', parameters('name'))]",
+              "scope": "[resourceId('Microsoft.Web/sites', parameters('name'))]",
               "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
               "properties": {
                 "copy": [
@@ -43593,8 +43593,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.39.26.7824",
-                      "templateHash": "5308269420307571977"
+                      "version": "0.43.8.12551",
+                      "templateHash": "1009721598684973971"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -54840,8 +54840,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.39.26.7824",
-              "templateHash": "5805872877074593071"
+              "version": "0.43.8.12551",
+              "templateHash": "9739523049889844356"
             }
           },
           "parameters": {

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -73,6 +73,9 @@
     },
     "MCPContainerRegistryHostname": {
       "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT}"
-    }
+    },
+    "tags": {
+       "value": "${AZURE_ENV_TAGS}"
+      }
   }
 }

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -91,6 +91,9 @@
     },
     "MCPContainerRegistryHostname": {
       "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT}"
-    }
+    },
+    "tags": {
+       "value": "${AZURE_ENV_TAGS}"
+      }
   }
 }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1134,7 +1134,10 @@ module containerAppEnvironment 'br/public:avm/res/app/managed-environment:0.13.1
   params: {
     name: containerAppEnvironmentResourceName
     location: location
-    tags: tags
+    tags: {
+      ...resourceGroup().tags
+      ...tags
+    }
     enableTelemetry: enableTelemetry
     // WAF aligned configuration for Private Networking
     publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1137,6 +1137,10 @@ module containerAppEnvironment 'br/public:avm/res/app/managed-environment:0.13.1
     tags: {
       ...resourceGroup().tags
       ...tags
+      TemplateName: 'MACAE'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+      CreatedBy: createdBy
+      DeploymentName: deployment().name
     }
     enableTelemetry: enableTelemetry
     // WAF aligned configuration for Private Networking

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -1136,11 +1136,9 @@ module containerAppEnvironment 'br/public:avm/res/app/managed-environment:0.13.1
     location: location
     tags: {
       ...resourceGroup().tags
+      ...existingTags
+      ...allTags
       ...tags
-      TemplateName: 'MACAE'
-      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
-      CreatedBy: createdBy
-      DeploymentName: deployment().name
     }
     enableTelemetry: enableTelemetry
     // WAF aligned configuration for Private Networking


### PR DESCRIPTION
## Purpose
This pull request focuses on improving tag management for deployed resources and making minor template optimizations in the infrastructure code. The main enhancement is the merging of resource group tags with custom tags for the container app environment, ensuring better consistency and traceability. Additionally, there are small updates to resource scoping and dependency ordering, as well as changes to the Bicep-to-ARM template generator metadata.

**Tag management improvements:**

* Updated the `containerAppEnvironment` module in both `infra/main.bicep` and `infra/main_custom.bicep` to merge `resourceGroup().tags` with custom `tags`, ensuring that all resources inherit tags from the resource group in addition to any custom tags. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1139-R1142) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L1137-R1140)
* Modified the corresponding ARM template (`infra/main.json`) to use `shallowMerge(createArray(resourceGroup().tags, parameters('tags')))`, aligning the JSON output with the new tag merging logic.

**Template and resource definition updates:**

* Changed the `scope` property for some resources (e.g., `Microsoft.CognitiveServices/accounts` and `Microsoft.Web/sites`) to use `format()` instead of `resourceId()` for improved clarity and consistency. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L24619-R24619) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L43521-R43521)
* Adjusted the ordering of dependencies in the `dependsOn` array for private DNS zones to ensure correct deployment sequencing.

**Bicep/ARM template metadata:**

* Updated the Bicep template generator version and template hash metadata throughout `infra/main.json` to reflect the changes and maintain consistency. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4994-R4995) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L24311-R24312) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L28015-R28016) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L42564-R42565) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L43596-R43597) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L54843-R54844)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->