### PR TITLE
fix: Add toaster message of failure in logs

### DIFF
--- a/src/App/src/components/content/streaming/StreamingAgentMessage.tsx
+++ b/src/App/src/components/content/streaming/StreamingAgentMessage.tsx
@@ -176,11 +176,13 @@ const renderAgentMessages = (
                   <Body1 className={styles.agentName}>
                     {getAgentDisplayName(msg.agent)}
                   </Body1>
-                  <Tag
-                    appearance="brand"
-                  >
-                    AI Agent
-                  </Tag>
+                  {msg.agent_type !== AgentMessageType.SYSTEM_AGENT && msg.agent?.toLowerCase() !== 'system' && (
+                    <Tag
+                      appearance="brand"
+                    >
+                      AI Agent
+                    </Tag>
+                  )}
                 </div>
               )}
 

--- a/src/App/src/hooks/usePlanWebSocket.tsx
+++ b/src/App/src/hooks/usePlanWebSocket.tsx
@@ -17,6 +17,7 @@ import {
     selectPlanApproved,
     approvalRequestReceived,
     planCompletedFinal,
+    planFailedFinal,
 } from '@/store/slices/planSlice';
 import {
     setSubmittingChatDisableInput,
@@ -178,16 +179,18 @@ export function usePlanWebSocket({
             WebsocketMessageType.FINAL_RESULT_MESSAGE,
             (finalMessage: any) => {
                 if (!finalMessage) return;
-                const agentMessageData: AgentMessageData = {
-                    agent: AgentType.GROUP_CHAT_MANAGER,
-                    agent_type: AgentMessageType.AI_AGENT,
-                    timestamp: Date.now(),
-                    steps: [],
-                    next_steps: [],
-                    content: '\u{1F389}\u{1F389} ' + (finalMessage.data?.content || ''),
-                    raw_data: finalMessage,
-                };
-                if (finalMessage?.data?.status === PlanStatus.COMPLETED) {
+                const messageStatus = finalMessage?.data?.status;
+
+                if (messageStatus === PlanStatus.COMPLETED) {
+                    const agentMessageData: AgentMessageData = {
+                        agent: AgentType.GROUP_CHAT_MANAGER,
+                        agent_type: AgentMessageType.AI_AGENT,
+                        timestamp: Date.now(),
+                        steps: [],
+                        next_steps: [],
+                        content: '\u{1F389}\u{1F389} ' + (finalMessage.data?.content || ''),
+                        raw_data: finalMessage,
+                    };
                     dispatch(setShowBufferingText(true));
                     dispatch(addAgentMessage(agentMessageData));
                     dispatch(setSelectedTeam(planData?.team || null));
@@ -196,11 +199,29 @@ export function usePlanWebSocket({
                     scrollToBottom();
                     webSocketService.disconnect();
                     persistAgentMessage(agentMessageData, planData, dispatch, true, streamingMessageBuffer);
+                } else if (messageStatus === 'error') {
+                    // Safety net: handle error status sent as FINAL_RESULT_MESSAGE
+                    const errorContent = finalMessage.data?.content || 'An unexpected error occurred. Please try again later.';
+                    const errorAgent: AgentMessageData = {
+                        agent: 'system',
+                        agent_type: AgentMessageType.SYSTEM_AGENT,
+                        timestamp: Date.now(),
+                        steps: [],
+                        next_steps: [],
+                        content: formatErrorMessage(errorContent),
+                        raw_data: finalMessage || '',
+                    };
+                    dispatch(addAgentMessage(errorAgent));
+                    dispatch(planFailedFinal());
+                    dispatch(setShowBufferingText(false));
+                    scrollToBottom();
+                    showToast(errorContent, 'error');
+                    webSocketService.disconnect();
                 }
             },
         );
         return unsub;
-    }, [dispatch, scrollToBottom, planData, streamingMessageBuffer]);
+    }, [dispatch, scrollToBottom, planData, streamingMessageBuffer, formatErrorMessage, showToast]);
 
     // ── ERROR_MESSAGE ─────────────────────────────────────────────
     useEffect(() => {
@@ -231,11 +252,11 @@ export function usePlanWebSocket({
                     raw_data: errorMessage || '',
                 };
                 dispatch(addAgentMessage(errorAgent));
-                dispatch(setShowProcessingPlanSpinner(false));
+                dispatch(planFailedFinal());
                 dispatch(setShowBufferingText(false));
-                dispatch(setSubmittingChatDisableInput(false));
                 scrollToBottom();
                 showToast(errorContent, 'error');
+                webSocketService.disconnect();
             },
         );
         return unsub;

--- a/src/App/src/store/slices/planSlice.ts
+++ b/src/App/src/store/slices/planSlice.ts
@@ -161,6 +161,14 @@ const planSlice = createSlice({
             }
         },
 
+        /** Single dispatch when an error occurs during plan execution */
+        planFailedFinal(state) {
+            state.showProcessingPlanSpinner = false;
+            if (state.planData?.plan) {
+                (state.planData as any).plan.overall_status = PlanStatus.FAILED;
+            }
+        },
+
         /** Reset everything back to initial state (used when navigating to a new plan) */
         resetPlan() {
             return { ...initialState };
@@ -229,6 +237,7 @@ export const {
     planApprovalRejected,
     approvalRequestReceived,
     planCompletedFinal,
+    planFailedFinal,
     resetPlan,
 } = planSlice.actions;
 

--- a/src/backend/v4/api/router.py
+++ b/src/backend/v4/api/router.py
@@ -371,7 +371,20 @@ async def process_request(
     try:
 
         async def run_orchestration_task():
-            await OrchestrationManager().run_orchestration(user_id, input_task)
+            try:
+                await OrchestrationManager().run_orchestration(user_id, input_task, plan_id=plan_id)
+            except Exception as orch_error:
+                logger.error("Background orchestration failed for plan '%s': %s", plan_id, orch_error)
+                track_event_if_configured(
+                    "Error_Orchestration_Failed",
+                    {
+                        "plan_id": plan_id,
+                        "session_id": input_task.session_id,
+                        "user_id": user_id,
+                        "error": str(orch_error),
+                        "error_type": type(orch_error).__name__,
+                    },
+                )
 
         background_tasks.add_task(run_orchestration_task)
 

--- a/src/backend/v4/orchestration/orchestration_manager.py
+++ b/src/backend/v4/orchestration/orchestration_manager.py
@@ -38,6 +38,8 @@ from v4.config.settings import connection_config, orchestration_config
 from v4.models.messages import WebsocketMessageType
 from v4.orchestration.human_approval_manager import HumanApprovalMagenticManager
 from v4.magentic_agents.magentic_agent_factory import MagenticAgentFactory
+from common.database.database_factory import DatabaseFactory
+from v4.models.models import PlanStatus
 
 
 class OrchestrationManager:
@@ -47,6 +49,7 @@ class OrchestrationManager:
 
     def __init__(self):
         self.user_id: Optional[str] = None
+        self._plan_id: Optional[str] = None
         self.logger = self.__class__.logger
 
     def _extract_response_text(self, data) -> str:
@@ -293,10 +296,11 @@ class OrchestrationManager:
     # ---------------------------
     # Execution
     # ---------------------------
-    async def run_orchestration(self, user_id: str, input_task) -> None:
+    async def run_orchestration(self, user_id: str, input_task, plan_id: str = None) -> None:
         """
         Execute the Magentic workflow for the provided user and task description.
         """
+        self._plan_id = plan_id
         job_id = str(uuid.uuid4())
         orchestration_config.set_approval_pending(job_id)
         self.logger.info(
@@ -545,19 +549,50 @@ class OrchestrationManager:
                 self.logger.error("Error attributes: %s", e.__dict__)
             self.logger.info("=" * 50)
 
-            # Send error status to user
+            # Build a user-friendly error message
+            error_str = str(e)
+            if "Too Many Requests" in error_str or "429" in error_str:
+                user_error_message = (
+                    "The service is currently experiencing high demand (rate limit exceeded). "
+                    "Please wait a moment and try again."
+                )
+            elif "timeout" in error_str.lower():
+                user_error_message = (
+                    "The request timed out while processing. Please try again."
+                )
+            elif "conflict" in error_str.lower() or "modified concurrently" in error_str.lower():
+                user_error_message = (
+                    "A conflict occurred while processing your request. "
+                    "The resource was modified by another operation. Please start a new task and try again."
+                )
+            else:
+                user_error_message = "An error occurred while processing your request. Please start a new task and try again."
+
+            # Update plan status to failed in the database
+            try:
+                if self._plan_id:
+                    memory_store = await DatabaseFactory.get_database(user_id=user_id)
+                    plan = await memory_store.get_plan_by_plan_id(plan_id=self._plan_id)
+                    if plan:
+                        plan.overall_status = PlanStatus.FAILED
+                        await memory_store.update_plan(plan)
+                        self.logger.info("Plan '%s' status updated to FAILED", self._plan_id)
+            except Exception as db_error:
+                self.logger.error("Failed to update plan status to FAILED: %s", db_error)
+
+            # Send error status to user via ERROR_MESSAGE type
             try:
                 await connection_config.send_status_update_async(
                     {
-                        "type": WebsocketMessageType.FINAL_RESULT_MESSAGE,
+                        "type": WebsocketMessageType.ERROR_MESSAGE,
                         "data": {
-                            "content": f"Error during orchestration: {str(e)}",
+                            "content": user_error_message,
                             "status": "error",
                             "timestamp": asyncio.get_event_loop().time(),
                         },
                     },
                     user_id,
-                    message_type=WebsocketMessageType.FINAL_RESULT_MESSAGE,
+                    message_type=WebsocketMessageType.ERROR_MESSAGE,
                 )
             except Exception as send_error:
                 self.logger.error("Failed to send error status: %s", send_error)

--- a/src/tests/backend/v4/orchestration/test_orchestration_manager.py
+++ b/src/tests/backend/v4/orchestration/test_orchestration_manager.py
@@ -277,6 +277,7 @@ class MockDatabaseBase:
 
 sys.modules['common.database'] = Mock()
 sys.modules['common.database.database_base'] = Mock(DatabaseBase=MockDatabaseBase)
+sys.modules['common.database.database_factory'] = Mock(DatabaseFactory=Mock())
 
 # Mock v4 modules
 class MockTeamService:
@@ -315,9 +316,18 @@ sys.modules['v4.config.settings'] = Mock(
 class MockWebsocketMessageType:
     """Mock WebsocketMessageType."""
     FINAL_RESULT_MESSAGE = "final_result_message"
+    ERROR_MESSAGE = "error_message"
+    AGENT_MESSAGE = "agent_message"
+
+class MockPlanStatus:
+    """Mock PlanStatus."""
+    FAILED = "failed"
+    COMPLETED = "completed"
+    IN_PROGRESS = "in_progress"
 
 sys.modules['v4.models'] = Mock()
 sys.modules['v4.models.messages'] = Mock(WebsocketMessageType=MockWebsocketMessageType)
+sys.modules['v4.models.models'] = Mock(PlanStatus=MockPlanStatus)
 
 # Mock v4.orchestration.human_approval_manager
 class MockHumanApprovalMagenticManager:


### PR DESCRIPTION
## Purpose
<img width="1907" height="907" alt="image" src="https://github.com/user-attachments/assets/997b8708-68dc-45c5-b631-17ca928d288c" />


This pull request introduces improved error handling for plan orchestration, ensuring that errors are communicated more clearly to users and that the plan status is consistently updated to "FAILED" in both the frontend and backend. The changes affect both the backend orchestration logic and the frontend WebSocket/message handling, providing better feedback and state management when orchestration fails.

**Backend error handling and plan status updates:**

* The backend now catches exceptions during orchestration, generates user-friendly error messages based on the error type (e.g., rate limits, timeouts, conflicts), and updates the plan's `overall_status` to `FAILED` in the database if a plan ID is present.
* Error messages are sent to the frontend using the `ERROR_MESSAGE` WebSocket message type, rather than as a `FINAL_RESULT_MESSAGE`.
* The orchestration manager now receives and stores the `plan_id` for error tracking and database updates. [[1]](diffhunk://#diff-a28c4028fee9cf923f4706f0d941e09fbcdfc4faa2aff56f911ce1455352396bL374-R387) [[2]](diffhunk://#diff-104c4f1066b1ada88859c59db484e96301dc74eedbe8987ece66e9dfc4211f4aL296-R303) [[3]](diffhunk://#diff-104c4f1066b1ada88859c59db484e96301dc74eedbe8987ece66e9dfc4211f4aR52)

**Frontend error handling and UI updates:**

* The frontend WebSocket hook (`usePlanWebSocket`) now listens for error statuses in both `FINAL_RESULT_MESSAGE` and `ERROR_MESSAGE` types. On error, it displays a user-friendly error message, updates the UI state (e.g., disables spinners, shows toasts), and dispatches the new `planFailedFinal` action to update the Redux store. [[1]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8R182-R184) [[2]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8R202-R224) [[3]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8L234-R259)
* A new Redux action, `planFailedFinal`, is introduced to set the plan status to `FAILED` and hide processing spinners in the UI. [[1]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R164-R171) [[2]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R240)
* The error-handling code ensures the WebSocket is disconnected after an error, preventing further processing of failed plans. [[1]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8R202-R224) [[2]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8L234-R259)

These changes provide a more robust and user-friendly experience when orchestration errors occur, ensuring the application's state accurately reflects failures and that users receive clear feedback.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->