### PR TITLE
refactor: Updated Foundry Roles name

### DIFF
--- a/docs/LocalDevelopmentSetup.md
+++ b/docs/LocalDevelopmentSetup.md
@@ -273,8 +273,8 @@ az cosmosdb sql role assignment create --resource-group <solution-accelerator-rg
 **Assign the required roles:**
 
 ```bash
-# Azure AI User role
-az role assignment create --assignee <aad-user-upn> --role "Azure AI User" --scope /subscriptions/<subscription-id>/resourceGroups/<solution-accelerator-rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-account-name>/projects/<foundry-project-name>
+# Foundry User role
+az role assignment create --assignee <aad-user-upn> --role "Foundry User" --scope /subscriptions/<subscription-id>/resourceGroups/<solution-accelerator-rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-account-name>/projects/<foundry-project-name>
 ```
 
 ```bash

--- a/docs/re-use-foundry-project.md
+++ b/docs/re-use-foundry-project.md
@@ -44,9 +44,9 @@ Replace `<Existing Foundry Project Resource ID>` with the value obtained from St
 Proceed with the next steps in the [deployment guide](DeploymentGuide.md#deployment-steps).
 
 > **Note:**  
-> After deployment, if you want to access agents created by the accelerator via the Azure AI Foundry Portal, or if you plan to debug or run the application locally, you must assign yourself either the **Azure AI User** or **Azure AI Developer** role for the Foundry resource.  
+> After deployment, if you want to access agents created by the accelerator via the Azure AI Foundry Portal, or if you plan to debug or run the application locally, you must assign yourself either the **Foundry User** or **Azure AI Developer** role for the Foundry resource.  
 > You can do this in the Azure Portal under the Foundry resource's "Access control (IAM)" section,  
 > **or** run the following command in your terminal (replace `<aad-user-upn>` with your Azure AD user principal name and `<resource-id>` with the Resource ID you copied in Step 5):
 > ```bash
-> az role assignment create --assignee <aad-user-upn> --role "Azure AI User" --scope <resource-id>
+> az role assignment create --assignee <aad-user-upn> --role "Foundry User" --scope <resource-id>
 > ```

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -854,7 +854,7 @@ module existingAiFoundryAiServicesDeployments 'modules/ai-services-deployments.b
     ]
     roleAssignments: [
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: userAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -935,7 +935,7 @@ module aiFoundryAiServices 'br:mcr.microsoft.com/bicep/avm/res/cognitive-service
     managedIdentities: { userAssignedResourceIds: [userAssignedIdentity!.outputs.resourceId] } //To create accounts or projects, you must enable a managed identity on your resource
     roleAssignments: [
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: userAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -950,7 +950,7 @@ module aiFoundryAiServices 'br:mcr.microsoft.com/bicep/avm/res/cognitive-service
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: deployingUserPrincipalId
         principalType: deployerPrincipalType
       }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,11 +5,11 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "8490920419623942773"
+      "version": "0.43.8.12551",
+      "templateHash": "12475542446442392463"
     },
     "name": "Multi-Agent Custom Automation Engine",
-    "description": "This module contains the resources required to deploy the [Multi-Agent Custom Automation Engine solution accelerator](https://github.com/microsoft/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator) for both Sandbox environments and WAF aligned environments.\r\n\r\n> **Note:** This module is not intended for broad, generic use, as it was designed by the Commercial Solution Areas CTO team, as a Microsoft Solution Accelerator. Feature requests and bug fix requests are welcome if they support the needs of this organization but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case. This module will likely be updated to leverage AVM resource modules in the future. This may result in breaking changes in upcoming versions when these features are implemented.\r\n"
+    "description": "This module contains the resources required to deploy the [Multi-Agent Custom Automation Engine solution accelerator](https://github.com/microsoft/Multi-Agent-Custom-Automation-Engine-Solution-Accelerator) for both Sandbox environments and WAF aligned environments.\n\n> **Note:** This module is not intended for broad, generic use, as it was designed by the Commercial Solution Areas CTO team, as a Microsoft Solution Accelerator. Feature requests and bug fix requests are welcome if they support the needs of this organization but may not be incorporated if they aim to make this module more generic than what it needs to be for its primary use case. This module will likely be updated to leverage AVM resource modules in the future. This may result in breaking changes in upcoming versions when these features are implemented.\n"
   },
   "parameters": {
     "solutionName": {
@@ -4991,8 +4991,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "4286500745908716598"
+              "version": "0.43.8.12551",
+              "templateHash": "9540091515555271756"
             }
           },
           "definitions": {
@@ -24308,8 +24308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "6570260143045999127"
+              "version": "0.43.8.12551",
+              "templateHash": "7866379492866507946"
             }
           },
           "definitions": {
@@ -28012,8 +28012,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "14513113443903512301"
+              "version": "0.43.8.12551",
+              "templateHash": "2868048678223903575"
             }
           },
           "parameters": {
@@ -42561,8 +42561,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15053339789155096730"
+              "version": "0.43.8.12551",
+              "templateHash": "18345308984648474640"
             }
           },
           "definitions": {
@@ -43593,8 +43593,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "16493651611122310009"
+                      "version": "0.43.8.12551",
+                      "templateHash": "1009721598684973971"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -54840,8 +54840,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "4859654437121510695"
+              "version": "0.43.8.12551",
+              "templateHash": "9739523049889844356"
             }
           },
           "parameters": {

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -853,7 +853,7 @@ module existingAiFoundryAiServicesDeployments 'modules/ai-services-deployments.b
     ]
     roleAssignments: [
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: userAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -934,7 +934,7 @@ module aiFoundryAiServices 'br:mcr.microsoft.com/bicep/avm/res/cognitive-service
     managedIdentities: { userAssignedResourceIds: [userAssignedIdentity!.outputs.resourceId] } //To create accounts or projects, you must enable a managed identity on your resource
     roleAssignments: [
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: userAssignedIdentity.outputs.principalId
         principalType: 'ServicePrincipal'
       }
@@ -949,7 +949,7 @@ module aiFoundryAiServices 'br:mcr.microsoft.com/bicep/avm/res/cognitive-service
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+        roleDefinitionIdOrName: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
         principalId: deployingUserPrincipalId
         principalType: deployerPrincipalType
       }

--- a/infra/scripts/assign_azure_ai_user_role.sh
+++ b/infra/scripts/assign_azure_ai_user_role.sh
@@ -25,25 +25,25 @@ fi
 
 IFS=',' read -r -a principal_ids_array <<< $principal_ids
 
-echo "Assigning Azure AI User role role to users"
+echo "Assigning Foundry User role to users"
 
 echo "Using provided Azure AI resource id: $aif_resource_id"
 
 for principal_id in "${principal_ids_array[@]}"; do
 
-    # Check if the user has the Azure AI User role
-    echo "Checking if user - ${principal_id} has the Azure AI User role"
+    # Check if the user has the Foundry User role
+    echo "Checking if user - ${principal_id} has the Foundry User role"
     role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list --role 53ca6127-db72-4b80-b1b0-d745d6d5456d --scope $aif_resource_id --assignee $principal_id --query "[].roleDefinitionId" -o tsv)
     if [ -z "$role_assignment" ]; then
-        echo "User - ${principal_id} does not have the Azure AI User role. Assigning the role."
+        echo "User - ${principal_id} does not have the Foundry User role. Assigning the role."
         MSYS_NO_PATHCONV=1 az role assignment create --assignee $principal_id --role 53ca6127-db72-4b80-b1b0-d745d6d5456d --scope $aif_resource_id --output none
         if [ $? -eq 0 ]; then
-            echo "Azure AI User role assigned successfully."
+            echo "Foundry User role assigned successfully."
         else
-            echo "Failed to assign Azure AI User role."
+            echo "Failed to assign Foundry User role."
             exit 1
         fi
     else
-        echo "User - ${principal_id} already has the Azure AI User role."
+        echo "User - ${principal_id} already has the Foundry User role."
     fi
 done


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates the naming of the Azure role used for Foundry access throughout the codebase and documentation, changing references from "Azure AI User" to "Foundry User". This ensures consistency with Azure's current role naming and helps avoid confusion for users and developers. Additionally, the infrastructure templates have been regenerated with a newer Bicep version.

**Role name updates:**

* All references to the "Azure AI User" role have been replaced with "Foundry User" in Bicep modules (`infra/main.bicep`, `infra/main_custom.bicep`) for both user-assigned identities and deploying users. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L857-R857) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L938-R938) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L953-R953) [[4]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L856-R856) [[5]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L937-R937) [[6]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L952-R952)
* The Bash script `assign_azure_ai_user_role.sh` now refers to "Foundry User" instead of "Azure AI User" in all output messages and logic.
* Documentation has been updated to instruct users to assign the "Foundry User" role rather than "Azure AI User". [[1]](diffhunk://#diff-55a5226de8be9fd740c4331c2d3ad776ee0a8958b27594f1d6673d38c12c32a4L276-R277) [[2]](diffhunk://#diff-baedcc134f509d83f06b1749bd81694ce39a239dcbbb055c297ad26b1869f083L47-R51)

**Infrastructure template regeneration:**

* The main ARM template (`infra/main.json`) has been regenerated with Bicep version 0.43.8, updating the `_generator` metadata and `templateHash` values. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R12) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4994-R4995) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L24311-R24312) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L28015-R28016) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L42564-R42565) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L43596-R43597) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L54843-R54844)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->