### PR TITLE
fix: Changes to Alive the Approval Session

### DIFF
--- a/src/App/src/api/httpClient.ts
+++ b/src/App/src/api/httpClient.ts
@@ -20,7 +20,7 @@ class HttpClient {
     private responseInterceptors: ResponseInterceptor[] = [];
     private timeout: number;
 
-    constructor(baseUrl = '', timeout = 180000) {
+    constructor(baseUrl = '', timeout = 30000) {
         this.baseUrl = baseUrl;
         this.timeout = timeout;
     }

--- a/src/App/src/api/httpClient.ts
+++ b/src/App/src/api/httpClient.ts
@@ -20,7 +20,7 @@ class HttpClient {
     private responseInterceptors: ResponseInterceptor[] = [];
     private timeout: number;
 
-    constructor(baseUrl = '', timeout = 30000) {
+    constructor(baseUrl = '', timeout = 180000) {
         this.baseUrl = baseUrl;
         this.timeout = timeout;
     }

--- a/src/App/src/pages/PlanPage.tsx
+++ b/src/App/src/pages/PlanPage.tsx
@@ -182,19 +182,37 @@ const PlanPage: React.FC = () => {
         if (!planApprovalRequest) return;
         dispatch(setProcessingApproval(true));
         const id = showToast('Submitting Approval', 'progress');
-        try {
-            await apiService.approvePlan({
+
+        const submitApproval = () =>
+            apiService.approvePlan({
                 m_plan_id: planApprovalRequest.id,
                 plan_id: planData?.plan?.id ?? '',
                 approved: true,
                 feedback: 'Plan approved by user',
             });
+
+        try {
+            await submitApproval();
             dismissToast(id);
             /* P0: single compound action replaces 3 separate dispatches */
             dispatch(planApprovalAccepted());
-        } catch {
-            dismissToast(id);
-            showToast('Failed to submit approval', 'error');
+        } catch (firstError) {
+            // Approval failed — the backend may have timed out or the WS dropped.
+            // Reconnect the WebSocket and retry once before giving up.
+            try {
+                if (!webSocketService.isConnected() && planData?.plan?.id) {
+                    await webSocketService.connect(planData.plan.id);
+                }
+                await submitApproval();
+                dismissToast(id);
+                dispatch(planApprovalAccepted());
+            } catch {
+                dismissToast(id);
+                showToast(
+                    'Failed to submit approval. The plan may have timed out — please start a new task and try again.',
+                    'error',
+                );
+            }
         } finally {
             dispatch(setProcessingApproval(false));
         }

--- a/src/App/src/store/WebSocketService.tsx
+++ b/src/App/src/store/WebSocketService.tsx
@@ -11,6 +11,7 @@ class WebSocketService {
     private listeners: Map<string, Set<(message: StreamMessage) => void>> = new Map();
     private planSubscriptions: Set<string> = new Set();
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
     private isConnecting = false;
     private intentionalDisconnect = false;
     private lastPlanId: string | undefined;
@@ -59,6 +60,7 @@ class WebSocketService {
                         clearTimeout(this.reconnectTimer);
                         this.reconnectTimer = null;
                     }
+                    this.startKeepalive();
                     this.emit('connection_status', { connected: true });
                     resolve();
                 };
@@ -75,6 +77,7 @@ class WebSocketService {
                 this.ws.onclose = (event) => {
                     this.isConnecting = false;
                     this.ws = null;
+                    this.stopKeepalive();
                     this.emit('connection_status', { connected: false });
                     /* P1: Only auto-reconnect if not intentional and not a clean close */
                     if (!this.intentionalDisconnect && event.code !== 1000 &&
@@ -99,6 +102,7 @@ class WebSocketService {
 
     disconnect(): void {
         this.intentionalDisconnect = true;
+        this.stopKeepalive();
         if (this.reconnectTimer) {
             clearTimeout(this.reconnectTimer);
             this.reconnectTimer = null;
@@ -197,6 +201,11 @@ class WebSocketService {
     }
 
     private handleMessage(message: StreamMessage): void {
+        // Ignore keepalive ping/pong messages from the server
+        const msgType = message.type as string;
+        if (msgType === 'ping' || msgType === 'pong') {
+            return;
+        }
 
         switch (message.type) {
             case WebsocketMessageType.PLAN_APPROVAL_REQUEST: {
@@ -274,6 +283,28 @@ class WebSocketService {
                 this.emit(message.type, message);
                 break;
             }
+        }
+    }
+
+    private startKeepalive(): void {
+        this.stopKeepalive();
+        // Send a ping every 30 seconds to prevent idle timeout from
+        // Azure Container Apps / reverse proxies closing the WebSocket.
+        this.keepaliveTimer = setInterval(() => {
+            if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+                try {
+                    this.ws.send(JSON.stringify({ type: 'pong' }));
+                } catch {
+                    // If send fails, the onclose handler will trigger reconnect
+                }
+            }
+        }, 30_000);
+    }
+
+    private stopKeepalive(): void {
+        if (this.keepaliveTimer) {
+            clearInterval(this.keepaliveTimer);
+            this.keepaliveTimer = null;
         }
     }
 

--- a/src/backend/v4/api/router.py
+++ b/src/backend/v4/api/router.py
@@ -93,18 +93,26 @@ async def start_comms(
         # Keep the connection open - FastAPI will close the connection if this returns
         try:
             # Keep the connection open - FastAPI will close the connection if this returns
+            # Send periodic pings to prevent idle timeout from Azure infra / reverse proxies.
+            ping_interval = 30  # seconds
+            last_ping = asyncio.get_event_loop().time()
             while True:
                 # no expectation that we will receive anything from the client but this keeps
                 # the connection open and does not take cpu cycle
                 try:
-                    message = await websocket.receive_text()
+                    message = await asyncio.wait_for(
+                        websocket.receive_text(), timeout=ping_interval
+                    )
+                    last_ping = asyncio.get_event_loop().time()
                     logging.debug(f"Received WebSocket message from {user_id}: {message}")
                 except asyncio.TimeoutError:
-                    # Ignore timeouts to keep the WebSocket connection open, but avoid a tight loop.
-                    logging.debug(
-                        f"WebSocket receive timeout for user {user_id}, process {process_id}"
-                    )
-                    await asyncio.sleep(0.1)
+                    # No message received within ping_interval — send a ping to keep alive.
+                    try:
+                        await websocket.send_text('{"type":"ping"}')
+                        last_ping = asyncio.get_event_loop().time()
+                    except Exception:
+                        logging.info(f"Ping failed for {user_id}/{process_id}, connection likely closed")
+                        break
                 except WebSocketDisconnect:
                     dc_props = {"process_id": process_id, "user_id": user_id}
                     if session_id:
@@ -537,7 +545,8 @@ async def plan_approval(
                     human_feedback.m_plan_id
                 )
                 raise HTTPException(
-                    status_code=404, detail="No active plan found for approval"
+                    status_code=404,
+                    detail="No active plan found for approval. The plan may have timed out due to inactivity. Please start a new task.",
                 )
     except Exception as e:
         logging.error(f"Error processing plan approval: {e}")

--- a/src/backend/v4/api/router.py
+++ b/src/backend/v4/api/router.py
@@ -95,7 +95,6 @@ async def start_comms(
             # Keep the connection open - FastAPI will close the connection if this returns
             # Send periodic pings to prevent idle timeout from Azure infra / reverse proxies.
             ping_interval = 30  # seconds
-            last_ping = asyncio.get_event_loop().time()
             while True:
                 # no expectation that we will receive anything from the client but this keeps
                 # the connection open and does not take cpu cycle
@@ -103,13 +102,11 @@ async def start_comms(
                     message = await asyncio.wait_for(
                         websocket.receive_text(), timeout=ping_interval
                     )
-                    last_ping = asyncio.get_event_loop().time()
                     logging.debug(f"Received WebSocket message from {user_id}: {message}")
                 except asyncio.TimeoutError:
                     # No message received within ping_interval — send a ping to keep alive.
                     try:
                         await websocket.send_text('{"type":"ping"}')
-                        last_ping = asyncio.get_event_loop().time()
                     except Exception:
                         logging.info(f"Ping failed for {user_id}/{process_id}, connection likely closed")
                         break

--- a/src/backend/v4/config/settings.py
+++ b/src/backend/v4/config/settings.py
@@ -97,8 +97,10 @@ class OrchestrationConfig:
         self._approval_events: Dict[str, asyncio.Event] = {}
         self._clarification_events: Dict[str, asyncio.Event] = {}
 
-        # Default timeout (seconds) for waiting operations
-        self.default_timeout: float = 300.0
+        # Default timeout (seconds) for waiting operations.
+        # Set to 30 minutes to allow users time to review plans before approving.
+        # Previous value of 300s (5 min) caused approval failures after idle periods.
+        self.default_timeout: float = 1800.0
 
     def get_current_orchestration(self, user_id: str) -> Any:
         """Get existing orchestration workflow instance for user_id."""

--- a/src/backend/v4/config/settings.py
+++ b/src/backend/v4/config/settings.py
@@ -98,8 +98,6 @@ class OrchestrationConfig:
         self._clarification_events: Dict[str, asyncio.Event] = {}
 
         # Default timeout (seconds) for waiting operations.
-        # Set to 30 minutes to allow users time to review plans before approving.
-        # Previous value of 300s (5 min) caused approval failures after idle periods.
         self.default_timeout: float = 1800.0
 
     def get_current_orchestration(self, user_id: str) -> Any:

--- a/src/tests/backend/v4/config/test_settings.py
+++ b/src/tests/backend/v4/config/test_settings.py
@@ -212,7 +212,7 @@ class TestOrchestrationConfig(IsolatedAsyncioTestCase):
         self.assertEqual(config.max_rounds, 20)
         self.assertIsInstance(config._approval_events, dict)
         self.assertIsInstance(config._clarification_events, dict)
-        self.assertEqual(config.default_timeout, 300.0)
+        self.assertEqual(config.default_timeout, 1800.0)
 
     def test_get_current_orchestration(self):
         """Test getting current orchestration."""


### PR DESCRIPTION
## Purpose
This pull request implements robust WebSocket keepalive mechanisms on both the frontend and backend to prevent idle timeouts, improves error handling and user feedback for plan approvals, and increases backend operation timeouts to reduce premature failures. The main changes are grouped below.

**WebSocket Keepalive and Stability Improvements:**

* Added a periodic keepalive ("ping"/"pong") mechanism to the frontend `WebSocketService` to prevent idle disconnects, including sending a "pong" every 30 seconds and ignoring keepalive messages in the message handler. The keepalive is started on connect and stopped on disconnect or close. (`src/App/src/store/WebSocketService.tsx`) [[1]](diffhunk://#diff-1344d5623b5de8de06a96a52515612975cc9175af82fbaa8022deb4579acdf25R14) [[2]](diffhunk://#diff-1344d5623b5de8de06a96a52515612975cc9175af82fbaa8022deb4579acdf25R63) [[3]](diffhunk://#diff-1344d5623b5de8de06a96a52515612975cc9175af82fbaa8022deb4579acdf25R80) [[4]](diffhunk://#diff-1344d5623b5de8de06a96a52515612975cc9175af82fbaa8022deb4579acdf25R105) [[5]](diffhunk://#diff-1344d5623b5de8de06a96a52515612975cc9175af82fbaa8022deb4579acdf25R204-R208) [[6]](diffhunk://#diff-1344d5623b5de8de06a96a52515612975cc9175af82fbaa8022deb4579acdf25R289-R310)

* The backend WebSocket handler now sends periodic "ping" messages every 30 seconds if no client message is received, preventing idle timeouts from Azure infrastructure or reverse proxies. (`src/backend/v4/api/router.py`)

**Plan Approval Error Handling and User Feedback:**

* Improved the plan approval submission flow to handle backend timeouts or dropped WebSocket connections by attempting a reconnect and retrying once before failing, and updated user-facing error messages for clarity. (`src/App/src/pages/PlanPage.tsx`)

* Enhanced the backend error message for plan approval when no active plan is found, informing users that the plan may have timed out and advising them to start a new task. (`src/backend/v4/api/router.py`)

**Backend Timeout Configuration:**

* Increased the default backend timeout for waiting operations from 5 minutes (300 seconds) to 30 minutes (1800 seconds) to reduce the likelihood of premature timeouts during long-running workflows. (`src/backend/v4/config/settings.py`)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->