### PR TITLE
test: Address unreachable statement warnings in test cases

### DIFF
--- a/src/tests/backend/common/database/test_database_base.py
+++ b/src/tests/backend/common/database/test_database_base.py
@@ -501,7 +501,7 @@ class TestDatabaseBaseContextManager:
                 raise ValueError("Test exception")
 
         # Even with exception, close should have been called
-        assert database.closed is True
+        assert database.closed is True  # lgtm[py/unreachable-statement]
 
 
 class TestDatabaseBaseInheritance:

--- a/src/tests/backend/v4/config/test_settings.py
+++ b/src/tests/backend/v4/config/test_settings.py
@@ -344,7 +344,7 @@ class TestOrchestrationConfig(IsolatedAsyncioTestCase):
         cancel_task_handle = asyncio.create_task(cancel_task())
         
         with self.assertRaises(asyncio.CancelledError):
-            await task
+            await task  # lgtm[py/statement-has-no-effect]
         
         _ = await cancel_task_handle
         self.assertTrue(task.cancelled())
@@ -365,7 +365,7 @@ class TestOrchestrationConfig(IsolatedAsyncioTestCase):
         cancel_task_handle = asyncio.create_task(cancel_task())
         
         with self.assertRaises(asyncio.CancelledError):
-            await task
+            await task  # lgtm[py/statement-has-no-effect]
         
         _ = await cancel_task_handle
         self.assertTrue(task.cancelled())


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request adds code analysis suppression comments to unit tests to address lgtm warnings without changing the test logic.

Code analysis suppressions:

* Added `# lgtm[py/unreachable-statement]` to an assertion in `test_database_base.py` to suppress an unreachable statement warning.
* Added `# lgtm[py/statement-has-no-effect]` to two `await task` statements in `test_settings.py` to suppress statement-has-no-effect warnings. [[1]](diffhunk://#diff-2c3ac366758d2a59c90c79aa0fa7d76332bfcaea72356cae933e7f0d0fc98612L347-R347) [[2]](diffhunk://#diff-2c3ac366758d2a59c90c79aa0fa7d76332bfcaea72356cae933e7f0d0fc98612L368-R368)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->