### PR TITLE
fix: Add Pop up when Plan Approval session is end and also handle old plan…

### DIFF
--- a/src/App/src/api/httpClient.ts
+++ b/src/App/src/api/httpClient.ts
@@ -20,7 +20,7 @@ class HttpClient {
     private responseInterceptors: ResponseInterceptor[] = [];
     private timeout: number;
 
-    constructor(baseUrl = '', timeout = 180000) {
+    constructor(baseUrl = '', timeout = 30000) {
         this.baseUrl = baseUrl;
         this.timeout = timeout;
     }

--- a/src/App/src/api/httpClient.ts
+++ b/src/App/src/api/httpClient.ts
@@ -20,7 +20,7 @@ class HttpClient {
     private responseInterceptors: ResponseInterceptor[] = [];
     private timeout: number;
 
-    constructor(baseUrl = '', timeout = 30000) {
+    constructor(baseUrl = '', timeout = 180000) {
         this.baseUrl = baseUrl;
         this.timeout = timeout;
     }

--- a/src/App/src/components/common/PlanTimeoutDialog.tsx
+++ b/src/App/src/components/common/PlanTimeoutDialog.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogSurface,
+  DialogTitle,
+  DialogContent,
+  DialogBody,
+  DialogActions,
+  Button,
+} from '@fluentui/react-components';
+import { Warning20Regular } from '@fluentui/react-icons';
+import "../../styles/Panel.css";
+
+interface PlanTimeoutDialogProps {
+  isOpen: boolean;
+  onGoHome: () => void;
+  onCancel: () => void;
+}
+
+const PlanTimeoutDialog: React.FC<PlanTimeoutDialogProps> = ({
+  isOpen,
+  onGoHome,
+  onCancel,
+}) => {
+  return (
+    <Dialog open={isOpen}>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>
+            <div className="plan-cancellation-dialog-title">
+              <Warning20Regular className="plan-cancellation-warning-icon" />
+              Session Timed Out
+            </div>
+          </DialogTitle>
+          <DialogContent>
+            The plan approval request has timed out because no action was taken.
+            Please go to the Home page and create a new task.
+          </DialogContent>
+          <DialogActions>
+            <Button
+              appearance="secondary"
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              appearance="primary"
+              onClick={onGoHome}
+            >
+              Go To Home Page
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+export default PlanTimeoutDialog;

--- a/src/App/src/hooks/usePlanWebSocket.tsx
+++ b/src/App/src/hooks/usePlanWebSocket.tsx
@@ -18,6 +18,7 @@ import {
     approvalRequestReceived,
     planCompletedFinal,
     planFailedFinal,
+    setShowTimeoutDialog,
 } from '@/store/slices/planSlice';
 import {
     setSubmittingChatDisableInput,
@@ -242,6 +243,17 @@ export function usePlanWebSocket({
                     const c = errorMessage.trim();
                     if (c.length > 0) errorContent = c;
                 }
+
+                // Detect timeout-specific error → show popup dialog instead of inline error
+                const isTimeout = errorContent.toLowerCase().includes('timed out');
+                if (isTimeout) {
+                    dispatch(planFailedFinal());
+                    dispatch(setShowBufferingText(false));
+                    dispatch(setShowTimeoutDialog(true));
+                    webSocketService.disconnect();
+                    return;
+                }
+
                 const errorAgent: AgentMessageData = {
                     agent: 'system',
                     agent_type: AgentMessageType.SYSTEM_AGENT,

--- a/src/App/src/pages/PlanPage.tsx
+++ b/src/App/src/pages/PlanPage.tsx
@@ -28,11 +28,13 @@ import {
     selectLoadingMessage,
     selectReloadLeftList,
     selectWaitingForPlan,
+    selectShowTimeoutDialog,
     setReloadLeftList,
     setProcessingApproval,
     setShowProcessingPlanSpinner,
     setShowCancellationDialog,
     setCancellingPlan,
+    setShowTimeoutDialog,
     setLoadingMessage,
     setErrorLoading,
     planApprovalAccepted,
@@ -73,6 +75,7 @@ import { useInlineToaster } from '../components/toast/InlineToaster';
 import Octo from '../commonComponents/imports/Octopus.png';
 import LoadingMessage, { loadingMessages } from '../commonComponents/components/LoadingMessage';
 import PlanCancellationDialog from '../components/common/PlanCancellationDialog';
+import PlanTimeoutDialog from '../components/common/PlanTimeoutDialog';
 import '../styles/PlanPage.css';
 
 // Singleton API service
@@ -99,6 +102,7 @@ const PlanPage: React.FC = () => {
     const showProcessingPlanSpinner = useAppSelector(selectShowProcessingPlanSpinner);
     const showCancellationDialog = useAppSelector(selectShowCancellationDialog);
     const cancellingPlan = useAppSelector(selectCancellingPlan);
+    const showTimeoutDialog = useAppSelector(selectShowTimeoutDialog);
     const loadingMessage = useAppSelector(selectLoadingMessage);
     const reloadLeftList = useAppSelector(selectReloadLeftList);
     const waitingForPlan = useAppSelector(selectWaitingForPlan);
@@ -387,6 +391,15 @@ const PlanPage: React.FC = () => {
                 onConfirm={handleConfirmCancellation}
                 onCancel={handleCancelDialog}
                 loading={cancellingPlan}
+            />
+
+            <PlanTimeoutDialog
+                isOpen={showTimeoutDialog}
+                onGoHome={() => {
+                    dispatch(setShowTimeoutDialog(false));
+                    navigate('/');
+                }}
+                onCancel={() => dispatch(setShowTimeoutDialog(false))}
             />
         </CoralShellColumn>
     );

--- a/src/App/src/store/slices/planSlice.ts
+++ b/src/App/src/store/slices/planSlice.ts
@@ -56,6 +56,8 @@ export interface PlanState {
     showCancellationDialog: boolean;
     /** Is a cancellation API call in progress? */
     cancellingPlan: boolean;
+    /** Show timeout popup when plan approval times out */
+    showTimeoutDialog: boolean;
     /** Loading message for spinners */
     loadingMessage: string;
 }
@@ -74,6 +76,7 @@ const initialState: PlanState = {
     reloadLeftList: true,
     showCancellationDialog: false,
     cancellingPlan: false,
+    showTimeoutDialog: false,
     loadingMessage: '',
 };
 
@@ -119,6 +122,9 @@ const planSlice = createSlice({
         },
         setCancellingPlan(state, action: PayloadAction<boolean>) {
             state.cancellingPlan = action.payload;
+        },
+        setShowTimeoutDialog(state, action: PayloadAction<boolean>) {
+            state.showTimeoutDialog = action.payload;
         },
         setLoadingMessage(state, action: PayloadAction<string>) {
             state.loadingMessage = action.payload;
@@ -231,6 +237,7 @@ export const {
     setReloadLeftList,
     setShowCancellationDialog,
     setCancellingPlan,
+    setShowTimeoutDialog,
     setLoadingMessage,
     markPlanCompleted,
     planApprovalAccepted,
@@ -254,6 +261,7 @@ export const selectContinueWithWebsocketFlow = (s: RootState) => s.plan.continue
 export const selectReloadLeftList = (s: RootState) => s.plan.reloadLeftList;
 export const selectShowCancellationDialog = (s: RootState) => s.plan.showCancellationDialog;
 export const selectCancellingPlan = (s: RootState) => s.plan.cancellingPlan;
+export const selectShowTimeoutDialog = (s: RootState) => s.plan.showTimeoutDialog;
 export const selectLoadingMessage = (s: RootState) => s.plan.loadingMessage;
 export const selectPlanStatus = (s: RootState) => s.plan.planData?.plan?.overall_status ?? null;
 export const selectPlanApproved = (s: RootState) => s.plan.planApproved;

--- a/src/backend/v4/api/router.py
+++ b/src/backend/v4/api/router.py
@@ -369,6 +369,10 @@ async def process_request(
         raise HTTPException(status_code=500, detail="Failed to create plan") from e
 
     try:
+        # Cancel any stale pending approvals from previous plans for this user.
+        # This ensures old background tasks (still waiting for approval) terminate
+        # silently instead of sending timeout errors to the user's current WebSocket.
+        orchestration_config.cancel_pending_approvals_for_user(user_id)
 
         async def run_orchestration_task():
             try:

--- a/src/backend/v4/config/settings.py
+++ b/src/backend/v4/config/settings.py
@@ -97,6 +97,10 @@ class OrchestrationConfig:
         self._approval_events: Dict[str, asyncio.Event] = {}
         self._clarification_events: Dict[str, asyncio.Event] = {}
 
+        # Track which user each pending plan belongs to, and which plans are superseded
+        self._plan_to_user: Dict[str, str] = {}  # plan_id -> user_id
+        self._superseded_plans: set = set()  # plan IDs cancelled by a new task
+
         # Default timeout (seconds) for waiting operations
         self.default_timeout: float = 300.0
 
@@ -104,13 +108,15 @@ class OrchestrationConfig:
         """Get existing orchestration workflow instance for user_id."""
         return self.orchestrations.get(user_id, None)
 
-    def set_approval_pending(self, plan_id: str) -> None:
+    def set_approval_pending(self, plan_id: str, user_id: str = None) -> None:
         """Mark approval pending and create/reset its event."""
         self.approvals[plan_id] = None
         if plan_id not in self._approval_events:
             self._approval_events[plan_id] = asyncio.Event()
         else:
             self._approval_events[plan_id].clear()
+        if user_id:
+            self._plan_to_user[plan_id] = user_id
 
     def set_approval_result(self, plan_id: str, approved: bool) -> None:
         """Set approval decision and trigger its event."""
@@ -214,6 +220,30 @@ class OrchestrationConfig:
         """Remove approval tracking data and event."""
         self.approvals.pop(plan_id, None)
         self._approval_events.pop(plan_id, None)
+        self._plan_to_user.pop(plan_id, None)
+        self._superseded_plans.discard(plan_id)
+
+    def cancel_pending_approvals_for_user(self, user_id: str) -> None:
+        """Cancel all pending approvals for a user (called when a new task starts).
+
+        Wakes up any blocking wait_for_approval calls so they return immediately.
+        The plan is marked as superseded so the orchestration can terminate silently
+        without sending error messages to the user's current WebSocket.
+        """
+        plans_to_cancel = [
+            pid for pid, uid in self._plan_to_user.items()
+            if uid == user_id and pid in self.approvals and self.approvals[pid] is None
+        ]
+        for plan_id in plans_to_cancel:
+            logger.info("Superseding stale pending approval: %s (user: %s)", plan_id, user_id)
+            self._superseded_plans.add(plan_id)
+            self.approvals[plan_id] = False
+            if plan_id in self._approval_events:
+                self._approval_events[plan_id].set()  # wake up the blocked wait
+
+    def is_plan_superseded(self, plan_id: str) -> bool:
+        """Check if a plan was superseded by a newer task from the same user."""
+        return plan_id in self._superseded_plans
 
     def cleanup_clarification(self, request_id: str) -> None:
         """Remove clarification tracking data and event."""

--- a/src/backend/v4/orchestration/exceptions.py
+++ b/src/backend/v4/orchestration/exceptions.py
@@ -1,0 +1,20 @@
+"""Custom exceptions for orchestration module."""
+
+
+class PlanSupersededError(Exception):
+    """Raised when a plan's approval wait is cancelled because the user started a new task."""
+
+    def __init__(self, plan_id: str):
+        self.plan_id = plan_id
+        super().__init__(f"Plan {plan_id} was superseded by a new task")
+
+
+class PlanTimeoutError(Exception):
+    """Raised when user does not approve/reject the plan within the timeout window."""
+
+    def __init__(self, plan_id: str, timeout_seconds: float = 0):
+        self.plan_id = plan_id
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"Plan {plan_id} approval timed out after {timeout_seconds}s"
+        )

--- a/src/backend/v4/orchestration/human_approval_manager.py
+++ b/src/backend/v4/orchestration/human_approval_manager.py
@@ -19,6 +19,7 @@ from agent_framework_orchestrations._magentic import (
 
 from v4.config.settings import connection_config, orchestration_config
 from v4.models.models import MPlan
+from v4.orchestration.exceptions import PlanSupersededError, PlanTimeoutError
 from v4.orchestration.helper.plan_to_mplan_converter import PlanToMPlanConverter
 
 logger = logging.getLogger(__name__)
@@ -330,43 +331,31 @@ DO NOT EVER OFFER TO HELP FURTHER IN THE FINAL ANSWER! Just provide the final an
             logger.error("No plan ID provided for approval")
             return messages.PlanApprovalResponse(approved=False, m_plan_id=m_plan_id)
 
-        orchestration_config.set_approval_pending(m_plan_id)
+        orchestration_config.set_approval_pending(m_plan_id, user_id=self.current_user_id)
 
         try:
             approved = await orchestration_config.wait_for_approval(m_plan_id)
+
+            # Check if this plan was superseded by a new task from the same user
+            if orchestration_config.is_plan_superseded(m_plan_id):
+                logger.info(
+                    "Plan %s was superseded by a new task - terminating silently",
+                    m_plan_id,
+                )
+                orchestration_config.cleanup_approval(m_plan_id)
+                raise PlanSupersededError(m_plan_id)
+
             logger.info("Approval received for plan %s: %s", m_plan_id, approved)
             return messages.PlanApprovalResponse(approved=approved, m_plan_id=m_plan_id)
 
         except asyncio.TimeoutError:
-            logger.debug(
-                "Approval timeout for plan %s - notifying user and terminating process",
+            logger.info(
+                "Approval timeout for plan %s after %ss",
                 m_plan_id,
+                orchestration_config.default_timeout,
             )
-
-            timeout_message = messages.TimeoutNotification(
-                timeout_type="approval",
-                request_id=m_plan_id,
-                message=f"Plan approval request timed out after {orchestration_config.default_timeout} seconds. Please try again.",
-                timestamp=asyncio.get_event_loop().time(),
-                timeout_duration=orchestration_config.default_timeout,
-            )
-
-            try:
-                await connection_config.send_status_update_async(
-                    message=timeout_message,
-                    user_id=self.current_user_id,
-                    message_type=messages.WebsocketMessageType.TIMEOUT_NOTIFICATION,
-                )
-                logger.info(
-                    "Timeout notification sent to user %s for plan %s",
-                    self.current_user_id,
-                    m_plan_id,
-                )
-            except Exception as e:
-                logger.error("Failed to send timeout notification: %s", e)
-
             orchestration_config.cleanup_approval(m_plan_id)
-            return None
+            raise PlanTimeoutError(m_plan_id, orchestration_config.default_timeout)
 
         except KeyError as e:
             logger.debug("Plan ID not found: %s - terminating process silently", e)
@@ -376,6 +365,10 @@ DO NOT EVER OFFER TO HELP FURTHER IN THE FINAL ANSWER! Just provide the final an
             logger.debug("Approval request %s was cancelled", m_plan_id)
             orchestration_config.cleanup_approval(m_plan_id)
             return None
+
+        except (PlanSupersededError, PlanTimeoutError):
+            # Let these propagate to orchestration_manager for proper handling
+            raise
 
         except Exception as e:
             logger.debug(

--- a/src/backend/v4/orchestration/human_approval_manager.py
+++ b/src/backend/v4/orchestration/human_approval_manager.py
@@ -19,7 +19,7 @@ from agent_framework_orchestrations._magentic import (
 
 from v4.config.settings import connection_config, orchestration_config
 from v4.models.models import MPlan
-from v4.orchestration.exceptions import PlanSupersededError, PlanTimeoutError
+from .exceptions import PlanSupersededError, PlanTimeoutError
 from v4.orchestration.helper.plan_to_mplan_converter import PlanToMPlanConverter
 
 logger = logging.getLogger(__name__)

--- a/src/backend/v4/orchestration/orchestration_manager.py
+++ b/src/backend/v4/orchestration/orchestration_manager.py
@@ -37,7 +37,7 @@ from v4.callbacks.response_handlers import (
 from v4.config.settings import connection_config, orchestration_config
 from v4.models.messages import WebsocketMessageType
 from v4.orchestration.human_approval_manager import HumanApprovalMagenticManager
-from v4.orchestration.exceptions import PlanSupersededError, PlanTimeoutError
+from .exceptions import PlanSupersededError, PlanTimeoutError
 from v4.magentic_agents.magentic_agent_factory import MagenticAgentFactory
 from common.database.database_factory import DatabaseFactory
 from v4.models.models import PlanStatus

--- a/src/backend/v4/orchestration/orchestration_manager.py
+++ b/src/backend/v4/orchestration/orchestration_manager.py
@@ -37,6 +37,7 @@ from v4.callbacks.response_handlers import (
 from v4.config.settings import connection_config, orchestration_config
 from v4.models.messages import WebsocketMessageType
 from v4.orchestration.human_approval_manager import HumanApprovalMagenticManager
+from v4.orchestration.exceptions import PlanSupersededError, PlanTimeoutError
 from v4.magentic_agents.magentic_agent_factory import MagenticAgentFactory
 from common.database.database_factory import DatabaseFactory
 from v4.models.models import PlanStatus
@@ -540,6 +541,67 @@ class OrchestrationManager:
                 message_type=WebsocketMessageType.FINAL_RESULT_MESSAGE,
             )
             self.logger.info("Final result sent via WebSocket to user '%s'", user_id)
+
+        except PlanSupersededError:
+            # Plan was superseded by a new task from the same user.
+            # Terminate silently — do NOT send error messages to the WebSocket
+            # because the user has already moved on to a new plan.
+            self.logger.info(
+                "Plan '%s' was superseded by a new task — terminating silently",
+                self._plan_id,
+            )
+            # Update plan status to failed in the database (housekeeping)
+            try:
+                if self._plan_id:
+                    memory_store = await DatabaseFactory.get_database(user_id=user_id)
+                    plan = await memory_store.get_plan_by_plan_id(plan_id=self._plan_id)
+                    if plan:
+                        plan.overall_status = PlanStatus.FAILED
+                        await memory_store.update_plan(plan)
+                        self.logger.info("Superseded plan '%s' status updated to FAILED", self._plan_id)
+            except Exception as db_error:
+                self.logger.error("Failed to update superseded plan status: %s", db_error)
+            return  # Exit silently without sending error to user
+
+        except PlanTimeoutError as e:
+            # Plan approval timed out on the current active session.
+            # Send a timeout-specific user-friendly error via ERROR_MESSAGE.
+            self.logger.info(
+                "Plan '%s' approval timed out after %ss",
+                self._plan_id,
+                e.timeout_seconds,
+            )
+            # Update plan status to failed
+            try:
+                if self._plan_id:
+                    memory_store = await DatabaseFactory.get_database(user_id=user_id)
+                    plan = await memory_store.get_plan_by_plan_id(plan_id=self._plan_id)
+                    if plan:
+                        plan.overall_status = PlanStatus.FAILED
+                        await memory_store.update_plan(plan)
+                        self.logger.info("Timed-out plan '%s' status updated to FAILED", self._plan_id)
+            except Exception as db_error:
+                self.logger.error("Failed to update timed-out plan status: %s", db_error)
+            # Send timeout error to user
+            try:
+                await connection_config.send_status_update_async(
+                    {
+                        "type": WebsocketMessageType.ERROR_MESSAGE,
+                        "data": {
+                            "content": (
+                                "The plan approval request timed out because no action was taken. "
+                                "Please start a new task and try again."
+                            ),
+                            "status": "error",
+                            "timestamp": asyncio.get_event_loop().time(),
+                        },
+                    },
+                    user_id,
+                    message_type=WebsocketMessageType.ERROR_MESSAGE,
+                )
+            except Exception as send_error:
+                self.logger.error("Failed to send timeout error: %s", send_error)
+            return  # Don't re-raise; this is a handled terminal state
 
         except Exception as e:
             # Error handling

--- a/src/tests/backend/v4/orchestration/test_human_approval_manager.py
+++ b/src/tests/backend/v4/orchestration/test_human_approval_manager.py
@@ -227,6 +227,7 @@ sys.modules['v4.orchestration.helper.plan_to_mplan_converter'] = Mock(
 
 # Now import the module under test
 from backend.v4.orchestration.human_approval_manager import HumanApprovalMagenticManager
+from backend.v4.orchestration.exceptions import PlanSupersededError, PlanTimeoutError
 
 # Get mocked references for tests
 connection_config = sys.modules['v4.config.settings'].connection_config
@@ -248,6 +249,7 @@ class TestHumanApprovalMagenticManager(unittest.IsolatedAsyncioTestCase):
         orchestration_config.wait_for_approval.reset_mock()
         orchestration_config.wait_for_approval.return_value = True  # Default return value
         orchestration_config.cleanup_approval.reset_mock()
+        orchestration_config.is_plan_superseded = Mock(return_value=False)
         
         # Create mock agent for new API
         self.mock_agent = Mock()
@@ -448,7 +450,7 @@ class TestHumanApprovalMagenticManager(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(result.approved)
             self.assertEqual(result.m_plan_id, plan_id)
         
-        orchestration_config.set_approval_pending.assert_called_with(plan_id)
+        orchestration_config.set_approval_pending.assert_called_with(plan_id, user_id=self.user_id)
         orchestration_config.wait_for_approval.assert_called_with(plan_id)
 
     async def test_wait_for_user_approval_rejection(self):
@@ -485,32 +487,23 @@ class TestHumanApprovalMagenticManager(unittest.IsolatedAsyncioTestCase):
         plan_id = "test-plan-123"
         orchestration_config.wait_for_approval.side_effect = asyncio.TimeoutError()
         
-        # Execute
-        result = await self.manager._wait_for_user_approval(plan_id)
+        # Execute & Verify - should raise PlanTimeoutError
+        with self.assertRaises(PlanTimeoutError):
+            await self.manager._wait_for_user_approval(plan_id)
         
-        # Verify
-        self.assertIsNone(result)
-        
-        # Verify timeout notification was sent
-        connection_config.send_status_update_async.assert_called()
         orchestration_config.cleanup_approval.assert_called_with(plan_id)
 
     async def test_wait_for_user_approval_timeout_websocket_error(self):
-        """Test _wait_for_user_approval with timeout and WebSocket error."""
+        """Test _wait_for_user_approval with timeout raises PlanTimeoutError."""
         # Setup
         plan_id = "test-plan-123"
         orchestration_config.wait_for_approval.side_effect = asyncio.TimeoutError()
-        connection_config.send_status_update_async.side_effect = Exception("WebSocket error")
         
-        # Execute
-        result = await self.manager._wait_for_user_approval(plan_id)
+        # Execute & Verify - should raise PlanTimeoutError
+        with self.assertRaises(PlanTimeoutError):
+            await self.manager._wait_for_user_approval(plan_id)
         
-        # Verify
-        self.assertIsNone(result)
         orchestration_config.cleanup_approval.assert_called_with(plan_id)
-        
-        # Reset side effect
-        connection_config.send_status_update_async.side_effect = None
 
     async def test_wait_for_user_approval_key_error(self):
         """Test _wait_for_user_approval with KeyError."""


### PR DESCRIPTION

## Purpose
This pull request introduces robust handling for plan approval timeouts and superseded plans, improving both backend reliability and frontend user experience. The backend now distinguishes between plans that are superseded (when a user starts a new task before approving the previous one) and plans that time out due to inaction, handling each case appropriately. On the frontend, users are presented with a clear dialog when a plan approval times out, guiding them to start a new task.

**Backend: Plan approval timeout and supersession handling**

* Added mechanisms to track which user each pending plan belongs to and to mark plans as superseded when a new task is started by the same user, ensuring that only the latest plan is active for a user (`src/backend/v4/config/settings.py`, `cancel_pending_approvals_for_user`, `is_plan_superseded`, `set_approval_pending`) [[1]](diffhunk://#diff-04842a5c05b9928bd93d5b42ef2e35bca2fa02317a77394f3d8c7f63612aad20R100-R119) [[2]](diffhunk://#diff-04842a5c05b9928bd93d5b42ef2e35bca2fa02317a77394f3d8c7f63612aad20R223-R246).
* Introduced custom exceptions `PlanSupersededError` and `PlanTimeoutError` to clearly distinguish between a plan being superseded and a plan timing out, and refactored orchestration logic to use these exceptions for clean error propagation (`src/backend/v4/orchestration/exceptions.py`, `src/backend/v4/orchestration/human_approval_manager.py`, `src/backend/v4/orchestration/orchestration_manager.py`) [[1]](diffhunk://#diff-62184ee95a626e5fbdf47d495f4e05d9fbbf0e41476e59e754aa2de4b909b23dR1-R20) [[2]](diffhunk://#diff-7e4b9471972ac98ae1a6aad5952ebd050013f9c5677aa58ee16553ec796c1bcaL333-R358) [[3]](diffhunk://#diff-7e4b9471972ac98ae1a6aad5952ebd050013f9c5677aa58ee16553ec796c1bcaR369-R372) [[4]](diffhunk://#diff-104c4f1066b1ada88859c59db484e96301dc74eedbe8987ece66e9dfc4211f4aR545-R605).
* When a plan is superseded, the backend now terminates the orchestration silently without sending an error to the user; for timeouts, a user-friendly error message is sent via WebSocket and the plan status is updated to FAILED in the database (`src/backend/v4/orchestration/orchestration_manager.py`).
* Ensured that any stale pending approvals are cancelled when a new plan is started, preventing old background tasks from sending erroneous timeout errors to the user's current session (`src/backend/v4/api/router.py`).

**Frontend: User experience for plan approval timeouts**

* Added a `PlanTimeoutDialog` React component that is displayed when the backend signals a plan approval timeout, providing clear instructions to the user (`src/App/src/components/common/PlanTimeoutDialog.tsx`).
* Updated Redux state and selectors to track and control the visibility of the timeout dialog, and integrated dialog display logic into the `PlanPage` component (`src/App/src/store/slices/planSlice.ts`, `src/App/src/pages/PlanPage.tsx`, `src/App/src/hooks/usePlanWebSocket.tsx`) [[1]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R59-R60) [[2]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R79) [[3]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R126-R128) [[4]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R240) [[5]](diffhunk://#diff-fb182383471cf363a00d9fd1a8c3b679714d42207a908cb7873a105506b180a5R264) [[6]](diffhunk://#diff-c6e8b4b076ef082d44764cef7dfd4891bad1d94111fb2f976ddd448dab1eb3ddR31-R37) [[7]](diffhunk://#diff-c6e8b4b076ef082d44764cef7dfd4891bad1d94111fb2f976ddd448dab1eb3ddR78) [[8]](diffhunk://#diff-c6e8b4b076ef082d44764cef7dfd4891bad1d94111fb2f976ddd448dab1eb3ddR105) [[9]](diffhunk://#diff-c6e8b4b076ef082d44764cef7dfd4891bad1d94111fb2f976ddd448dab1eb3ddR395-R403) [[10]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8R21) [[11]](diffhunk://#diff-1e5ffe391f6535347835494719144cd141fae5af599ac4a047129fc61a6fd1a8R246-R256).

**Other improvements**

* Increased the default HTTP client timeout from 30s to 180s to better accommodate longer-running backend operations (`src/App/src/api/httpClient.ts`).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->