### PR TITLE
fix: updated the post deployment script for selected scenario run and WAF and EXP alignment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1967,17 +1967,15 @@ module searchServiceIdentity 'br/public:avm/res/search/search-service:0.11.1' = 
 // ========== Search Service MI → AI Services Role Assignment ========== //
 // The Search service system MI needs Cognitive Services OpenAI User on the AI Services account
 // so that Knowledge Base MCP tools can call the model for semantic retrieval.
-resource aiServicesForSearchRole 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = {
-  name: aiFoundryAiServicesResourceName
-}
-
-resource searchServiceOpenAIRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(aiServicesForSearchRole.id, searchServiceName, '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
-  scope: aiServicesForSearchRole
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd') // Cognitive Services OpenAI User
-    principalId: searchServiceIdentity.outputs.systemAssignedMIPrincipalId!
-    principalType: 'ServicePrincipal'
+// Deployed via a module scoped to the AI Services account's resource group so it works
+// for both new and existing (cross-RG / cross-subscription) Foundry deployments.
+module searchServiceOpenAIRole 'modules/search-openai-role.bicep' = {
+  name: take('module.search-openai-role.${solutionSuffix}', 64)
+  scope: resourceGroup(aiFoundryAiServicesSubscriptionId, aiFoundryAiServicesResourceGroupName)
+  params: {
+    aiFoundryAccountName: aiFoundryAiServicesResourceName
+    searchServicePrincipalId: searchServiceIdentity.outputs.systemAssignedMIPrincipalId!
+    roleNameGuidSeed: searchServiceName
   }
 }
 

--- a/infra/modules/search-openai-role.bicep
+++ b/infra/modules/search-openai-role.bicep
@@ -1,0 +1,24 @@
+// ========================================================================
+// Assigns "Cognitive Services OpenAI User" on an AI Services (Cognitive
+// Services) account to the Search service's system-assigned managed identity.
+// Deployed at the scope of the AI Services account's resource group so it
+// works for both new and existing (cross-RG / cross-subscription) Foundry.
+// ========================================================================
+
+param aiFoundryAccountName string
+param searchServicePrincipalId string
+param roleNameGuidSeed string
+
+resource aiServicesAccount 'Microsoft.CognitiveServices/accounts@2025-06-01' existing = {
+  name: aiFoundryAccountName
+}
+
+resource searchServiceOpenAIRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(aiServicesAccount.id, roleNameGuidSeed, '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
+  scope: aiServicesAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd') // Cognitive Services OpenAI User
+    principalId: searchServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/scripts/post_deploy.ps1
+++ b/infra/scripts/post_deploy.ps1
@@ -1,21 +1,25 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Interactive post-deployment data seeding script.
-    Seeds Cosmos DB (teams), uploads blob data, creates search indexes,
-    creates vector stores, and provisions Foundry IQ knowledge bases.
+    Interactive post-deployment data seeding script (azd postdeploy hook).
+    Uploads team configurations via the backend REST API, uploads sample
+    blob data, creates AI Search indexes, vector stores, Foundry IQ knowledge
+    bases, and KB MCP connections.
 
 .DESCRIPTION
-    Run after 'azd up' completes. Pulls configuration from azd environment
-    outputs. Presents an interactive menu to select which use cases to install.
-    Writes teams directly to Cosmos DB (no running backend required).
+    Mirrors the structure of infra/scripts/Selecting-Team-Config-And-Data.ps1.
+    Configuration values are resolved using a 3-tier fallback strategy:
+      1. azd env  -> 2. ARM deployment outputs  -> 3. resource naming convention
+    Handles WAF deployments by temporarily enabling public network access on
+    Storage Account and AI Search Service for the duration of the data
+    seeding, then restoring the original setting in a finally block.
 
 .PARAMETER ResourceGroup
     Optional resource group name. If omitted, values come from azd env.
 
 .EXAMPLE
-    .\infra\scripts\post_deploy_data.ps1
-    .\infra\scripts\post_deploy_data.ps1 -ResourceGroup rg-macae-dev
+    .\infra\scripts\post_deploy.ps1
+    .\infra\scripts\post_deploy.ps1 -ResourceGroup rg-macae-dev
 #>
 
 param(
@@ -24,24 +28,309 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
-$script:hasErrors = $false
+
+# Variables (script scope so helpers can populate them)
+$script:backendUrl                 = ""
+$script:storageAccount             = ""
+$script:aiSearch                   = ""
+$script:aiSearchEndpoint           = ""
+$script:openaiEndpoint             = ""
+$script:projectEndpoint            = ""
+$script:azSubscriptionId           = ""
+$script:stIsPublicAccessDisabled   = $false
+$script:srchIsPublicAccessDisabled = $false
+$script:aiFoundryIsPublicAccessDisabled = $false
+$script:aiFoundryAccountName      = ""
+$script:aiFoundryResourceGroup    = ""
+$script:hasErrors                  = $false
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Helper functions
+# WAF helpers — temporarily enable / restore public network access
+# ──────────────────────────────────────────────────────────────────────────────
+
+function Restore-NetworkAccess {
+    if (-not $script:ResourceGroup -or -not $script:storageAccount -or -not $script:aiSearch) {
+        return
+    }
+
+    $rgTypeTag = (az group show --name $script:ResourceGroup --query "tags.Type" -o tsv 2>$null)
+    if ($rgTypeTag -ne "WAF") {
+        return
+    }
+
+    if ($script:stIsPublicAccessDisabled -or $script:srchIsPublicAccessDisabled) {
+        Write-Host ""
+        Write-Host "=== Restoring network access settings ==="
+    }
+
+    if ($script:stIsPublicAccessDisabled) {
+        $currentAccess = (az storage account show --name $script:storageAccount --resource-group $script:ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null)
+        if ($currentAccess -eq "Enabled") {
+            Write-Host "Disabling public access for Storage Account: $($script:storageAccount)"
+            az storage account update --name $script:storageAccount --resource-group $script:ResourceGroup --public-network-access disabled --default-action Deny --output none 2>$null
+            Write-Host "✓ Storage Account public access disabled"
+        } else {
+            Write-Host "✓ Storage Account access unchanged (already at desired state)"
+        }
+    }
+
+    if ($script:srchIsPublicAccessDisabled) {
+        $currentAccess = (az search service show --name $script:aiSearch --resource-group $script:ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null)
+        if ($currentAccess -eq "Enabled") {
+            Write-Host "Disabling public access for AI Search Service: $($script:aiSearch)"
+            az search service update --name $script:aiSearch --resource-group $script:ResourceGroup --public-network-access disabled --output none 2>$null
+            Write-Host "✓ AI Search Service public access disabled"
+        } else {
+            Write-Host "✓ AI Search Service access unchanged (already at desired state)"
+        }
+    }
+
+    if ($script:aiFoundryIsPublicAccessDisabled -and $script:aiFoundryAccountName -and $script:aiFoundryResourceGroup) {
+        $currentAccess = (az cognitiveservices account show --name $script:aiFoundryAccountName --resource-group $script:aiFoundryResourceGroup --query "properties.publicNetworkAccess" -o tsv 2>$null)
+        if ($currentAccess -eq "Enabled") {
+            Write-Host "Disabling public access for AI Foundry: $($script:aiFoundryAccountName)"
+            az resource update --resource-group $script:aiFoundryResourceGroup --name $script:aiFoundryAccountName --resource-type "Microsoft.CognitiveServices/accounts" --set properties.publicNetworkAccess=Disabled --output none 2>$null
+            Write-Host "✓ AI Foundry public access disabled"
+        } else {
+            Write-Host "✓ AI Foundry access unchanged (already at desired state)"
+        }
+    }
+
+    if ($script:stIsPublicAccessDisabled -or $script:srchIsPublicAccessDisabled -or $script:aiFoundryIsPublicAccessDisabled) {
+        Write-Host "=========================================="
+    }
+}
+
+function Enable-PublicAccessIfWaf {
+    if (-not $script:ResourceGroup) { return }
+    $rgTypeTag = (az group show --name $script:ResourceGroup --query "tags.Type" -o tsv 2>$null)
+    if ($rgTypeTag -ne "WAF") { return }
+
+    Write-Host ""
+    Write-Host "=== WAF deployment detected — temporarily enabling public network access ==="
+
+    # Storage Account
+    $stPublicAccess = (az storage account show --name $script:storageAccount --resource-group $script:ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null)
+    if ($stPublicAccess -eq "Disabled") {
+        $script:stIsPublicAccessDisabled = $true
+        Write-Host "Enabling public access for Storage Account: $($script:storageAccount)"
+        az storage account update --name $script:storageAccount --resource-group $script:ResourceGroup --public-network-access enabled --default-action Allow --output none
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error: Failed to enable public access for storage account." -ForegroundColor Red
+            throw "Failed to enable storage public access"
+        }
+
+        Write-Host "Waiting 30 seconds for public access to propagate..."
+        Start-Sleep -Seconds 30
+
+        $maxRetries = 10
+        for ($i = 0; $i -lt $maxRetries; $i++) {
+            $currentAccess = (az storage account show --name $script:storageAccount --resource-group $script:ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null)
+            if ($currentAccess -eq "Enabled") {
+                Write-Host "✓ Storage Account public access enabled successfully"
+                break
+            }
+            Write-Host "Public access not yet enabled (attempt $($i + 1)/$maxRetries). Waiting 5 seconds..."
+            Start-Sleep -Seconds 5
+        }
+    } else {
+        Write-Host "✓ Storage Account public access already enabled"
+    }
+
+    # AI Search Service
+    $srchPublicAccess = (az search service show --name $script:aiSearch --resource-group $script:ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null)
+    if ($srchPublicAccess -eq "Disabled") {
+        $script:srchIsPublicAccessDisabled = $true
+        Write-Host "Enabling public access for AI Search Service: $($script:aiSearch)"
+        az search service update --name $script:aiSearch --resource-group $script:ResourceGroup --public-network-access enabled --output none
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error: Failed to enable public access for search service." -ForegroundColor Red
+            throw "Failed to enable search public access"
+        }
+
+        Write-Host "Waiting 30 seconds for public access to propagate..."
+        Start-Sleep -Seconds 30
+
+        $maxRetries = 10
+        for ($i = 0; $i -lt $maxRetries; $i++) {
+            $currentAccess = (az search service show --name $script:aiSearch --resource-group $script:ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null)
+            if ($currentAccess -eq "Enabled") {
+                Write-Host "✓ AI Search Service public access enabled successfully"
+                break
+            }
+            Write-Host "Public access not yet enabled (attempt $($i + 1)/$maxRetries). Waiting 5 seconds..."
+            Start-Sleep -Seconds 5
+        }
+    } else {
+        Write-Host "✓ AI Search Service public access already enabled"
+    }
+
+    # AI Foundry (Cognitive Services account) — name parsed from AZURE_OPENAI_ENDPOINT,
+    # RG parsed from AZURE_EXISTING_AI_PROJECT_RESOURCE_ID if set (existing foundry may live in a different RG).
+    if ($script:openaiEndpoint -and $script:openaiEndpoint -match '^https?://([^.]+)\.') {
+        $script:aiFoundryAccountName = $Matches[1]
+    }
+    $existingFoundryId = $(azd env get-value AZURE_EXISTING_AI_PROJECT_RESOURCE_ID 2>$null)
+    if ($existingFoundryId -and $existingFoundryId -match '/resourceGroups/([^/]+)/') {
+        $script:aiFoundryResourceGroup = $Matches[1]
+    } else {
+        $script:aiFoundryResourceGroup = $script:ResourceGroup
+    }
+
+    if ($script:aiFoundryAccountName -and $script:aiFoundryResourceGroup) {
+        $foundryPublicAccess = (az cognitiveservices account show --name $script:aiFoundryAccountName --resource-group $script:aiFoundryResourceGroup --query "properties.publicNetworkAccess" -o tsv 2>$null)
+        if ($foundryPublicAccess -eq "Disabled") {
+            $script:aiFoundryIsPublicAccessDisabled = $true
+            Write-Host "Enabling public access for AI Foundry: $($script:aiFoundryAccountName) (RG: $($script:aiFoundryResourceGroup))"
+            az resource update --resource-group $script:aiFoundryResourceGroup --name $script:aiFoundryAccountName --resource-type "Microsoft.CognitiveServices/accounts" --set properties.publicNetworkAccess=Enabled --output none
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "Error: Failed to enable public access for AI Foundry." -ForegroundColor Red
+                throw "Failed to enable AI Foundry public access"
+            }
+
+            Write-Host "Waiting 30 seconds for public access to propagate..."
+            Start-Sleep -Seconds 30
+
+            $maxRetries = 10
+            for ($i = 0; $i -lt $maxRetries; $i++) {
+                $currentAccess = (az cognitiveservices account show --name $script:aiFoundryAccountName --resource-group $script:aiFoundryResourceGroup --query "properties.publicNetworkAccess" -o tsv 2>$null)
+                if ($currentAccess -eq "Enabled") {
+                    Write-Host "✓ AI Foundry public access enabled successfully"
+                    break
+                }
+                Write-Host "Public access not yet enabled (attempt $($i + 1)/$maxRetries). Waiting 5 seconds..."
+                Start-Sleep -Seconds 5
+            }
+        } else {
+            Write-Host "✓ AI Foundry public access already enabled"
+        }
+    } else {
+        Write-Host "⚠ Could not determine AI Foundry account name/RG — skipping Foundry public-access toggle."
+    }
+
+    Write-Host "==========================================================="
+    Write-Host ""
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Configuration retrieval — 3-tier fallback
 # ──────────────────────────────────────────────────────────────────────────────
 
 function Test-AzdInstalled {
     try { $null = Get-Command azd -ErrorAction Stop; return $true } catch { return $false }
 }
 
-function Get-AzdValue([string]$Key) {
-    $val = $(azd env get-value $Key 2>$null)
-    if (-not $val) {
-        Write-Host "ERROR: Could not get '$Key' from azd env. Run 'azd up' first." -ForegroundColor Red
-        exit 1
+function Get-DeploymentValue {
+    param(
+        [object]$DeploymentOutputs,
+        [string]$PrimaryKey,
+        [string]$FallbackKey
+    )
+    $value = $null
+    if ($DeploymentOutputs.PSObject.Properties[$PrimaryKey]) {
+        $value = $DeploymentOutputs.$PrimaryKey.value
     }
-    return $val.Trim()
+    if (-not $value -and $DeploymentOutputs.PSObject.Properties[$FallbackKey]) {
+        $value = $DeploymentOutputs.$FallbackKey.value
+    }
+    return $value
 }
+
+function Get-ValuesFromAzdEnv {
+    if (-not (Test-AzdInstalled)) {
+        Write-Host "Error: Azure Developer CLI (azd) is not installed."
+        return $false
+    }
+
+    Write-Host "Getting values from azd environment..."
+
+    $script:backendUrl       = $(azd env get-value BACKEND_URL 2>$null)
+    $script:storageAccount   = $(azd env get-value AZURE_STORAGE_ACCOUNT_NAME 2>$null)
+    $script:aiSearch         = $(azd env get-value AZURE_AI_SEARCH_NAME 2>$null)
+    $script:aiSearchEndpoint = $(azd env get-value AZURE_SEARCH_ENDPOINT 2>$null)
+    $script:openaiEndpoint   = $(azd env get-value AZURE_OPENAI_ENDPOINT 2>$null)
+    $script:projectEndpoint  = $(azd env get-value AZURE_AI_PROJECT_ENDPOINT 2>$null)
+    $script:ResourceGroup    = $(azd env get-value AZURE_RESOURCE_GROUP 2>$null)
+
+    if (-not $script:backendUrl -or -not $script:storageAccount -or -not $script:aiSearch -or -not $script:ResourceGroup) {
+        Write-Host "Error: Could not retrieve all required values from azd environment."
+        return $false
+    }
+
+    Write-Host "Successfully retrieved values from azd environment."
+    return $true
+}
+
+function Get-ValuesFromAzDeployment {
+    Write-Host "Getting values from Azure deployment outputs..."
+
+    $deploymentName = az group show --name $script:ResourceGroup --query "tags.DeploymentName" -o tsv 2>$null
+    if (-not $deploymentName) {
+        Write-Host "Error: Could not find deployment name in resource group tags."
+        return $false
+    }
+
+    Write-Host "Fetching deployment outputs for deployment: $deploymentName"
+    $deploymentOutputs = az deployment group show --resource-group $script:ResourceGroup --name $deploymentName --query "properties.outputs" -o json 2>$null | ConvertFrom-Json
+    if (-not $deploymentOutputs) {
+        Write-Host "Error: Could not fetch deployment outputs."
+        return $false
+    }
+
+    $script:storageAccount   = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_STORAGE_ACCOUNT_NAME" -FallbackKey "azureStorageAccountName"
+    $script:aiSearch         = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_SEARCH_NAME"       -FallbackKey "azureAiSearchName"
+    $script:backendUrl       = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "backenD_URL"                -FallbackKey "backendUrl"
+    $script:aiSearchEndpoint = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_SEARCH_ENDPOINT"      -FallbackKey "azureSearchEndpoint"
+    $script:openaiEndpoint   = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_OPENAI_ENDPOINT"      -FallbackKey "azureOpenaiEndpoint"
+    $script:projectEndpoint  = Get-DeploymentValue -DeploymentOutputs $deploymentOutputs -PrimaryKey "azurE_AI_PROJECT_ENDPOINT"  -FallbackKey "azureAiProjectEndpoint"
+
+    if (-not $script:storageAccount -or -not $script:aiSearch -or -not $script:backendUrl) {
+        Write-Host "Error: Could not extract all required values from deployment outputs."
+        return $false
+    }
+
+    Write-Host "Successfully retrieved values from deployment outputs."
+    return $true
+}
+
+function Get-ValuesUsingSolutionSuffix {
+    Write-Host "Getting values from resource naming convention using solution suffix..."
+
+    $solutionSuffix = az group show --name $script:ResourceGroup --query "tags.SolutionSuffix" -o tsv 2>$null
+    if (-not $solutionSuffix) {
+        Write-Host "Error: Could not find SolutionSuffix tag in resource group."
+        return $false
+    }
+
+    Write-Host "Found solution suffix: $solutionSuffix"
+
+    $script:storageAccount = ("st$solutionSuffix") -replace '-', ''
+    $script:aiSearch       = "srch-$solutionSuffix"
+    $containerAppName      = "ca-$solutionSuffix"
+
+    Write-Host "Querying backend URL from Container App..."
+    $backendFqdn = az containerapp show --name $containerAppName --resource-group $script:ResourceGroup --query "properties.configuration.ingress.fqdn" -o tsv 2>$null
+    if (-not $backendFqdn) {
+        Write-Host "Error: Could not get Container App FQDN. Container App may not be deployed yet."
+        return $false
+    }
+    $script:backendUrl = "https://$backendFqdn"
+
+    # Endpoints (best-effort reconstruction; seed scripts will fail loudly if missing)
+    $script:aiSearchEndpoint = "https://$($script:aiSearch).search.windows.net"
+
+    if (-not $script:storageAccount -or -not $script:aiSearch -or -not $script:backendUrl) {
+        Write-Host "Error: Failed to reconstruct all required resource names."
+        return $false
+    }
+
+    Write-Host "Successfully reconstructed values from resource naming convention."
+    return $true
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Content pack deployment (blob upload + index creation)
+# ──────────────────────────────────────────────────────────────────────────────
 
 function Deploy-ContentPack {
     param(
@@ -61,7 +350,6 @@ function Deploy-ContentPack {
     Write-Host "  Deploying data for content pack: $($pack.name)"
     $hadFailure = $false
 
-    # blob_indexes: upload + create search index
     if ($pack.PSObject.Properties['blob_indexes'] -and $pack.blob_indexes) {
         foreach ($entry in $pack.blob_indexes) {
             $container = $entry.container
@@ -93,7 +381,6 @@ function Deploy-ContentPack {
         }
     }
 
-    # blob_uploads: upload only
     if ($pack.PSObject.Properties['blob_uploads'] -and $pack.blob_uploads) {
         foreach ($entry in $pack.blob_uploads) {
             $container = $entry.container
@@ -116,7 +403,6 @@ function Deploy-ContentPack {
         }
     }
 
-    # search_indexes: create index from already-uploaded data
     if ($pack.PSObject.Properties['search_indexes'] -and $pack.search_indexes) {
         foreach ($entry in $pack.search_indexes) {
             $indexName = $entry.index_name
@@ -141,347 +427,387 @@ function Deploy-ContentPack {
     return (-not $hadFailure)
 }
 
-# ──────────────────────────────────────────────────────────────────────────────
-# 1. Authenticate & resolve environment values
-# ──────────────────────────────────────────────────────────────────────────────
-
-Write-Host "`n========================================" -ForegroundColor Cyan
-Write-Host " Post-Deployment Data Seeding" -ForegroundColor Cyan
-Write-Host "========================================`n" -ForegroundColor Cyan
-
-# Verify Azure CLI login
-try {
-    $null = az account show 2>$null
-    Write-Host "Already authenticated with Azure."
-} catch {
-    Write-Host "Not authenticated. Logging in..."
-    az login
-}
-
-if (-not (Test-AzdInstalled)) {
-    Write-Host "ERROR: Azure Developer CLI (azd) is required. Install from https://aka.ms/azd" -ForegroundColor Red
-    exit 1
-}
-
-$cosmosEndpoint  = Get-AzdValue "COSMOSDB_ENDPOINT"
-$cosmosDatabase  = Get-AzdValue "COSMOSDB_DATABASE"
-$cosmosContainer = Get-AzdValue "COSMOSDB_CONTAINER"
-$storageAccount  = Get-AzdValue "AZURE_STORAGE_ACCOUNT_NAME"
-$aiSearchName    = Get-AzdValue "AZURE_AI_SEARCH_NAME"
-$searchEndpoint  = Get-AzdValue "AZURE_SEARCH_ENDPOINT"
-$openaiEndpoint  = Get-AzdValue "AZURE_OPENAI_ENDPOINT"
-$projectEndpoint = Get-AzdValue "AZURE_AI_PROJECT_ENDPOINT"
-
-if (-not $ResourceGroup) {
-    $ResourceGroup = $(azd env get-value AZURE_RESOURCE_GROUP 2>$null)
-}
-
-Write-Host ""
-Write-Host "Cosmos DB:       $cosmosEndpoint"
-Write-Host "Database:        $cosmosDatabase"
-Write-Host "Storage:         $storageAccount"
-Write-Host "AI Search:       $aiSearchName"
-Write-Host "OpenAI:          $openaiEndpoint"
-Write-Host "AI Project:      $projectEndpoint"
-Write-Host "Resource Group:  $ResourceGroup"
-Write-Host ""
-
-# ──────────────────────────────────────────────────────────────────────────────
-# 2. Interactive use case selection
-# ──────────────────────────────────────────────────────────────────────────────
-
-Write-Host "==============================================="
-Write-Host "Available Use Cases:"
-Write-Host "==============================================="
-Write-Host "1. RFP Evaluation"
-Write-Host "2. Retail Customer Satisfaction"
-Write-Host "3. HR Employee Onboarding"
-Write-Host "4. Marketing Press Release"
-Write-Host "5. Contract Compliance Review"
-Write-Host "6. Content Generation"
-Write-Host "7. All"
-Write-Host "==============================================="
-Write-Host ""
-
-do {
-    $useCaseSelection = Read-Host "Enter the number of the use case to install (1-7)"
-
-    if ($useCaseSelection -eq "all" -or $useCaseSelection -eq "7") {
-        $selectedUseCase = "All"
-        $useCaseValid = $true
-        Write-Host "Selected: All use cases will be installed."
-    }
-    elseif ($useCaseSelection -in @("1","2","3","4","5","6")) {
-        $useCaseNames = @{
-            "1" = "RFP Evaluation"
-            "2" = "Retail Customer Satisfaction"
-            "3" = "HR Employee Onboarding"
-            "4" = "Marketing Press Release"
-            "5" = "Contract Compliance Review"
-            "6" = "Content Generation"
-        }
-        $selectedUseCase = $useCaseNames[$useCaseSelection]
-        $useCaseValid = $true
-        Write-Host "Selected: $selectedUseCase"
-    }
-    else {
-        $useCaseValid = $false
-        Write-Host "Invalid selection. Please enter a number from 1-7." -ForegroundColor Red
-    }
-} while (-not $useCaseValid)
-
-Write-Host ""
-
-# ──────────────────────────────────────────────────────────────────────────────
-# 3. Set up Python environment
-# ──────────────────────────────────────────────────────────────────────────────
-
-$pythonCmd = $null
-try { $v = (python --version 2>&1); if ($v -match "Python \d") { $pythonCmd = "python" } } catch {}
-if (-not $pythonCmd) {
-    try { $v = (python3 --version 2>&1); if ($v -match "Python \d") { $pythonCmd = "python3" } } catch {}
-}
-if (-not $pythonCmd) {
-    Write-Host "ERROR: Python not found. Install Python 3.10+ and add to PATH." -ForegroundColor Red
-    exit 1
-}
-
-$venvPath = "infra/scripts/scriptenv"
-if (-not (Test-Path $venvPath)) {
-    Write-Host "Creating virtual environment..."
-    & $pythonCmd -m venv $venvPath
-}
-
-$activateScript = if (Test-Path "$venvPath/Scripts/Activate.ps1") { "$venvPath/Scripts/Activate.ps1" }
-                  elseif (Test-Path "$venvPath/bin/Activate.ps1") { "$venvPath/bin/Activate.ps1" }
-                  else { $null }
-if ($activateScript) { . $activateScript }
-
-Write-Host "Installing Python dependencies..."
-pip install --quiet -r infra/scripts/requirements.txt
-pip install --quiet azure-cosmos httpx aiohttp
-
-# ──────────────────────────────────────────────────────────────────────────────
-# 4. Ensure src/backend/.env has required values for seed scripts
-# ──────────────────────────────────────────────────────────────────────────────
-
-$envFile = "src/backend/.env"
-$envPairs = @{
-    "COSMOSDB_ENDPOINT"        = $cosmosEndpoint
-    "COSMOSDB_DATABASE"        = $cosmosDatabase
-    "COSMOSDB_CONTAINER"       = $cosmosContainer
-    "AZURE_STORAGE_ACCOUNT_NAME" = $storageAccount
-    "AZURE_AI_SEARCH_ENDPOINT" = $searchEndpoint
-    "AZURE_OPENAI_ENDPOINT"    = $openaiEndpoint
-    "AZURE_AI_PROJECT_ENDPOINT" = $projectEndpoint
-}
-
-if (Test-Path $envFile) {
-    $existing = Get-Content $envFile -Raw
-    foreach ($key in $envPairs.Keys) {
-        if ($existing -notmatch "(?m)^$key=") {
-            Add-Content -Path $envFile -Value "$key=$($envPairs[$key])"
-        }
-    }
-} else {
-    $lines = $envPairs.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }
-    Set-Content -Path $envFile -Value ($lines -join "`n")
-}
-
-# ──────────────────────────────────────────────────────────────────────────────
-# 5. Seed Cosmos DB with team configs (direct write — no backend needed)
-# ──────────────────────────────────────────────────────────────────────────────
-
-# Map use case selections to content pack team directories
-$teamPackMap = @{
-    "1" = @("content_packs/rfp_evaluation/agent_teams")
-    "2" = @("content_packs/retail_customer/agent_teams")
-    "3" = @("content_packs/hr_onboarding/agent_teams")
-    "4" = @("content_packs/marketing_press_release/agent_teams")
-    "5" = @("content_packs/contract_compliance/agent_teams")
-    "6" = @("content_packs/content_gen/agent_teams")
-    "7" = @(
-        "content_packs/rfp_evaluation/agent_teams",
-        "content_packs/retail_customer/agent_teams",
-        "content_packs/hr_onboarding/agent_teams",
-        "content_packs/marketing_press_release/agent_teams",
-        "content_packs/contract_compliance/agent_teams",
-        "content_packs/content_gen/agent_teams"
+function Upload-TeamConfig {
+    param(
+        [string]$Label,
+        [string]$TeamConfigDir,
+        [string]$TeamId,
+        [string]$PythonCmd
     )
+
+    Write-Host ""
+    Write-Host "Uploading Team Configuration for $Label..."
+    try {
+        $process = Start-Process -FilePath $PythonCmd `
+            -ArgumentList "infra/scripts/upload_team_config.py", $script:backendUrl, $TeamConfigDir, $script:userPrincipalId, $TeamId `
+            -Wait -NoNewWindow -PassThru
+        if ($process.ExitCode -ne 0) {
+            Write-Host "Error: Team configuration for $Label upload failed." -ForegroundColor Red
+            $script:hasErrors = $true
+            return $false
+        }
+    } catch {
+        Write-Host "Error: Uploading team configuration failed: $_" -ForegroundColor Red
+        $script:hasErrors = $true
+        return $false
+    }
+    Write-Host "Uploaded Team Configuration for $Label."
+    return $true
 }
 
-$selectedTeamDirs = $teamPackMap[$useCaseSelection]
+# ══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ══════════════════════════════════════════════════════════════════════════════
 
-Write-Host "`n── Step 1: Seeding Cosmos DB with team configs ──" -ForegroundColor Green
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host " Post-Deployment Data Seeding" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
 
-$teamDirsJson = ($selectedTeamDirs | ConvertTo-Json -Compress)
+try {
 
-$seedTeamsScript = @"
-import asyncio, json, uuid, sys, os
-from datetime import datetime, timezone
-from pathlib import Path
-from azure.cosmos.aio import CosmosClient
-from azure.identity.aio import DefaultAzureCredential
+    # ── Authenticate ──────────────────────────────────────────────────────────
+    try {
+        $null = az account show 2>$null
+        Write-Host "Already authenticated with Azure."
+    } catch {
+        Write-Host "Not authenticated. Logging in..."
+        az login
+    }
 
-ENDPOINT = os.environ["COSMOSDB_ENDPOINT"]
-DATABASE = os.environ["COSMOSDB_DATABASE"]
-CONTAINER = os.environ["COSMOSDB_CONTAINER"]
-TEAM_DIRS = json.loads(r'''$teamDirsJson''')
+    # ── Resolve subscription (allow user to switch if mismatched) ────────────
+    if (Test-AzdInstalled) {
+        try {
+            $script:azSubscriptionId = $(azd env get-value AZURE_SUBSCRIPTION_ID 2>$null)
+            if (-not $script:azSubscriptionId) { $script:azSubscriptionId = $env:AZURE_SUBSCRIPTION_ID }
+        } catch { $script:azSubscriptionId = "" }
+    }
 
-async def seed():
-    cred = DefaultAzureCredential()
-    client = CosmosClient(ENDPOINT, credential=cred)
-    db = client.get_database_client(DATABASE)
-    container = db.get_container_client(CONTAINER)
-    count = 0
+    $currentSubscriptionId   = az account show --query id   -o tsv
+    $currentSubscriptionName = az account show --query name -o tsv
 
-    for team_dir in TEAM_DIRS:
-        team_path = Path(team_dir)
-        if not team_path.exists():
-            print(f"  Warning: {team_dir} not found, skipping.")
-            continue
-        for filepath in sorted(team_path.glob("*.json")):
-            with open(filepath, "r", encoding="utf-8") as f:
-                json_data = json.load(f)
+    if ($script:azSubscriptionId -and $currentSubscriptionId -ne $script:azSubscriptionId) {
+        Write-Host "Current subscription is $currentSubscriptionName ( $currentSubscriptionId )."
+        $confirmation = Read-Host "Do you want to continue with this subscription? (y/n)"
+        if ($confirmation -notin @("y", "Y")) {
+            $availableSubscriptions = az account list --query "[?state=='Enabled'].[name,id]" --output tsv
+            $subscriptions = $availableSubscriptions -split "`n" | ForEach-Object { $_.Split("`t") }
 
-            unique_id = str(uuid.uuid4())
-            session_id = str(uuid.uuid4())
-            now = datetime.now(timezone.utc).isoformat()
+            do {
+                Write-Host ""
+                Write-Host "Available Subscriptions:"
+                Write-Host "========================"
+                for ($i = 0; $i -lt $subscriptions.Count; $i += 2) {
+                    $index = ($i / 2) + 1
+                    Write-Host "$index. $($subscriptions[$i]) ( $($subscriptions[$i + 1]) )"
+                }
+                Write-Host "========================"
 
-            doc = {
-                "id": unique_id,
-                "team_id": unique_id,
-                "session_id": session_id,
-                "data_type": "team_config",
-                "name": json_data.get("name", ""),
-                "status": json_data.get("status", "active"),
-                "created": now,
-                "created_by": "system",
-                "deployment_name": json_data.get("deployment_name", ""),
-                "agents": json_data.get("agents", []),
-                "description": json_data.get("description", ""),
-                "logo": json_data.get("logo", ""),
-                "plan": json_data.get("plan", ""),
-                "starting_tasks": json_data.get("starting_tasks", []),
-                "user_id": "system",
+                $subscriptionIndex = Read-Host "Enter the number of the subscription (1-$([int]($subscriptions.Count / 2)))"
+
+                if ($subscriptionIndex -match '^\d+$' -and [int]$subscriptionIndex -ge 1 -and [int]$subscriptionIndex -le ($subscriptions.Count / 2)) {
+                    $selectedIndex = ([int]$subscriptionIndex - 1) * 2
+                    $selectedSubscriptionName = $subscriptions[$selectedIndex]
+                    $selectedSubscriptionId   = $subscriptions[$selectedIndex + 1]
+                    az account set --subscription $selectedSubscriptionId
+                    Write-Host "Switched to subscription: $selectedSubscriptionName ( $selectedSubscriptionId )"
+                    $script:azSubscriptionId = $selectedSubscriptionId
+                    break
+                } else {
+                    Write-Host "Invalid selection. Please try again." -ForegroundColor Red
+                }
+            } while ($true)
+        } else {
+            az account set --subscription $currentSubscriptionId
+            $script:azSubscriptionId = $currentSubscriptionId
+        }
+    } else {
+        Write-Host "Proceeding with subscription: $currentSubscriptionName ( $currentSubscriptionId )"
+        az account set --subscription $currentSubscriptionId
+        $script:azSubscriptionId = $currentSubscriptionId
+    }
+
+    # ── Resolve config values (3-tier fallback) ───────────────────────────────
+    if (-not $ResourceGroup) {
+        if (-not (Get-ValuesFromAzdEnv)) {
+            Write-Host "Failed to get values from azd environment."
+            Write-Host "If you want to use deployment outputs instead, pass -ResourceGroup <name>."
+            exit 1
+        }
+    } else {
+        $script:ResourceGroup = $ResourceGroup
+        Write-Host "Resource group provided: $ResourceGroup"
+
+        if (-not (Get-ValuesFromAzDeployment)) {
+            Write-Host "Warning: Could not retrieve values from deployment outputs. Falling back to naming convention..." -ForegroundColor Yellow
+            if (-not (Get-ValuesUsingSolutionSuffix)) {
+                Write-Host "Error: Both fallback methods failed." -ForegroundColor Red
+                exit 1
+            }
+        }
+    }
+
+    # ── Use case selection ────────────────────────────────────────────────────
+    Write-Host ""
+    Write-Host "==============================================="
+    Write-Host "Available Use Cases:"
+    Write-Host "==============================================="
+    Write-Host "1. RFP Evaluation"
+    Write-Host "2. Retail Customer Satisfaction"
+    Write-Host "3. HR Employee Onboarding"
+    Write-Host "4. Marketing Press Release"
+    Write-Host "5. Contract Compliance Review"
+    Write-Host "6. Content Generation"
+    Write-Host "7. All"
+    Write-Host "==============================================="
+    Write-Host ""
+
+    do {
+        $useCaseSelection = Read-Host "Please enter the number of the use case you would like to install (1-7)"
+        switch ($useCaseSelection) {
+            "1" { $selectedUseCase = "RFP Evaluation";              $useCaseValid = $true }
+            "2" { $selectedUseCase = "Retail Customer Satisfaction"; $useCaseValid = $true }
+            "3" { $selectedUseCase = "HR Employee Onboarding";       $useCaseValid = $true }
+            "4" { $selectedUseCase = "Marketing Press Release";      $useCaseValid = $true }
+            "5" { $selectedUseCase = "Contract Compliance Review";   $useCaseValid = $true }
+            "6" { $selectedUseCase = "Content Generation";           $useCaseValid = $true }
+            "7" { $selectedUseCase = "All";                          $useCaseValid = $true }
+            "all" { $useCaseSelection = "7"; $selectedUseCase = "All"; $useCaseValid = $true }
+            default {
+                $useCaseValid = $false
+                Write-Host "Invalid selection. Please enter a number from 1-7." -ForegroundColor Red
+            }
+        }
+    } while (-not $useCaseValid)
+
+    Write-Host ""
+    Write-Host "==============================================="
+    Write-Host "Values to be used:"
+    Write-Host "==============================================="
+    Write-Host "Selected Use Case: $selectedUseCase"
+    Write-Host "Resource Group:    $($script:ResourceGroup)"
+    Write-Host "Backend URL:       $($script:backendUrl)"
+    Write-Host "Storage Account:   $($script:storageAccount)"
+    Write-Host "AI Search:         $($script:aiSearch)"
+    Write-Host "AI Project:        $($script:projectEndpoint)"
+    Write-Host "Subscription ID:   $($script:azSubscriptionId)"
+    Write-Host "==============================================="
+    Write-Host ""
+
+    # ── Signed-in user principal id (for backend API auth header) ─────────────
+    $script:userPrincipalId = az ad signed-in-user show --query id -o tsv
+    if (-not $script:userPrincipalId) {
+        Write-Host "Error: Could not retrieve signed-in user principal id." -ForegroundColor Red
+        exit 1
+    }
+
+    # ── Python environment ────────────────────────────────────────────────────
+    $pythonCmd = $null
+    try { $v = (python --version 2>&1);  if ($v -match "Python \d") { $pythonCmd = "python" } } catch {}
+    if (-not $pythonCmd) {
+        try { $v = (python3 --version 2>&1); if ($v -match "Python \d") { $pythonCmd = "python3" } } catch {}
+    }
+    if (-not $pythonCmd) {
+        Write-Host "ERROR: Python not found. Install Python 3.10+ and add it to PATH." -ForegroundColor Red
+        exit 1
+    }
+
+    $venvPath = "infra/scripts/scriptenv"
+    if (-not (Test-Path $venvPath)) {
+        Write-Host "Creating virtual environment..."
+        & $pythonCmd -m venv $venvPath
+    } else {
+        Write-Host "Virtual environment already exists. Skipping creation."
+    }
+
+    $activateScript = if (Test-Path "$venvPath/Scripts/Activate.ps1") { "$venvPath/Scripts/Activate.ps1" }
+                      elseif (Test-Path "$venvPath/bin/Activate.ps1") { "$venvPath/bin/Activate.ps1" }
+                      else { $null }
+    if ($activateScript) { . $activateScript }
+
+    Write-Host "Installing Python dependencies..."
+    pip install --quiet -r infra/scripts/requirements.txt
+
+    # ── Export endpoints as process env vars for seed scripts ────────────────
+    # Seed scripts read these via os.environ; we set them here so we don't
+    # need to write src/backend/.env.
+    if ($script:projectEndpoint)  { $env:AZURE_AI_PROJECT_ENDPOINT = $script:projectEndpoint }
+    if ($script:aiSearchEndpoint) { $env:AZURE_AI_SEARCH_ENDPOINT  = $script:aiSearchEndpoint }
+    if ($script:openaiEndpoint)   { $env:AZURE_OPENAI_ENDPOINT     = $script:openaiEndpoint }
+
+    # ── WAF: temporarily enable public access for use cases that need data ──
+    $usesData = $useCaseSelection -in @("1","2","5","6","7")
+    if ($usesData) {
+        Enable-PublicAccessIfWaf
+    }
+
+    $isTeamConfigFailed = $false
+    $isSampleDataFailed = $false
+
+    # ── Use Case 3: HR Onboarding (team config only, no data) ─────────────────
+    if ($useCaseSelection -in @("3","7")) {
+        if (-not (Upload-TeamConfig -Label "HR Employee Onboarding" `
+                    -TeamConfigDir "content_packs/hr_onboarding/agent_teams" `
+                    -TeamId "00000000-0000-0000-0000-000000000001" `
+                    -PythonCmd $pythonCmd)) {
+            $isTeamConfigFailed = $true
+        }
+    }
+
+    # ── Use Case 4: Marketing Press Release (team config only, no data) ──────
+    if ($useCaseSelection -in @("4","7")) {
+        if (-not (Upload-TeamConfig -Label "Marketing Press Release" `
+                    -TeamConfigDir "content_packs/marketing_press_release/agent_teams" `
+                    -TeamId "00000000-0000-0000-0000-000000000002" `
+                    -PythonCmd $pythonCmd)) {
+            $isTeamConfigFailed = $true
+        }
+    }
+
+    # ── Use Case 1: RFP Evaluation ────────────────────────────────────────────
+    if ($useCaseSelection -in @("1","7")) {
+        if (-not (Upload-TeamConfig -Label "RFP Evaluation" `
+                    -TeamConfigDir "content_packs/rfp_evaluation/agent_teams" `
+                    -TeamId "00000000-0000-0000-0000-000000000004" `
+                    -PythonCmd $pythonCmd)) {
+            $isTeamConfigFailed = $true
+        }
+
+        Write-Host "Deploying data for RFP Evaluation content pack..."
+        if (-not (Deploy-ContentPack -PackPath "content_packs/rfp_evaluation" -StorageAccountName $script:storageAccount -AiSearchName $script:aiSearch -PythonCmd $pythonCmd)) {
+            Write-Host "Error: Data deployment for RFP Evaluation failed." -ForegroundColor Red
+            $isSampleDataFailed = $true
+        }
+    }
+
+    # ── Use Case 5: Contract Compliance ───────────────────────────────────────
+    if ($useCaseSelection -in @("5","7")) {
+        if (-not (Upload-TeamConfig -Label "Contract Compliance Review" `
+                    -TeamConfigDir "content_packs/contract_compliance/agent_teams" `
+                    -TeamId "00000000-0000-0000-0000-000000000005" `
+                    -PythonCmd $pythonCmd)) {
+            $isTeamConfigFailed = $true
+        }
+
+        Write-Host "Deploying data for Contract Compliance content pack..."
+        if (-not (Deploy-ContentPack -PackPath "content_packs/contract_compliance" -StorageAccountName $script:storageAccount -AiSearchName $script:aiSearch -PythonCmd $pythonCmd)) {
+            Write-Host "Error: Data deployment for Contract Compliance failed." -ForegroundColor Red
+            $isSampleDataFailed = $true
+        }
+    }
+
+    # ── Use Case 2: Retail Customer Satisfaction ──────────────────────────────
+    if ($useCaseSelection -in @("2","7")) {
+        if (-not (Upload-TeamConfig -Label "Retail Customer Satisfaction" `
+                    -TeamConfigDir "content_packs/retail_customer/agent_teams" `
+                    -TeamId "00000000-0000-0000-0000-000000000003" `
+                    -PythonCmd $pythonCmd)) {
+            $isTeamConfigFailed = $true
+        }
+
+        Write-Host "Deploying data for Retail Customer content pack..."
+        if (-not (Deploy-ContentPack -PackPath "content_packs/retail_customer" -StorageAccountName $script:storageAccount -AiSearchName $script:aiSearch -PythonCmd $pythonCmd)) {
+            Write-Host "Error: Data deployment for Retail Customer Satisfaction failed." -ForegroundColor Red
+            $isSampleDataFailed = $true
+        }
+    }
+
+    # ── Use Case 6: Content Generation ────────────────────────────────────────
+    if ($useCaseSelection -in @("6","7")) {
+        if (-not (Upload-TeamConfig -Label "Content Generation" `
+                    -TeamConfigDir "content_packs/content_gen/agent_teams" `
+                    -TeamId "00000000-0000-0000-0000-000000000007" `
+                    -PythonCmd $pythonCmd)) {
+            $isTeamConfigFailed = $true
+        }
+
+        Write-Host "Deploying data for Content Generation content pack..."
+        if (-not (Deploy-ContentPack -PackPath "content_packs/content_gen" -StorageAccountName $script:storageAccount -AiSearchName $script:aiSearch -PythonCmd $pythonCmd)) {
+            Write-Host "Error: Data deployment for Content Generation failed." -ForegroundColor Red
+            $isSampleDataFailed = $true
+        }
+    }
+
+    if ($isTeamConfigFailed -or $isSampleDataFailed) {
+        $script:hasErrors = $true
+        Write-Host ""
+        Write-Host "One or more tasks failed. Please review the messages above." -ForegroundColor Yellow
+    }
+
+    # ── Vector stores / Foundry IQ KB / KB MCP connections ──────────────────
+    # Scoped to the selected use case via --only filter.
+    if ($usesData -and -not $isSampleDataFailed) {
+
+        # Map use case → vector store names (only Retail has vector stores today)
+        $vectorStoreMap = @{
+            "1" = @()
+            "2" = @("macae-retail-customer-data", "macae-retail-order-data")
+            "5" = @()
+            "6" = @()
+            "7" = @("macae-retail-customer-data", "macae-retail-order-data")
+        }
+
+        # Map use case → KB names (used for both seed_knowledge_bases and seed_kb_connections)
+        $kbMap = @{
+            "1" = @("macae-rfp-summary-kb", "macae-rfp-risk-kb", "macae-rfp-compliance-kb")
+            "2" = @("macae-retail-customer-kb", "macae-retail-orders-kb")
+            "5" = @("macae-contract-summary-kb", "macae-contract-risk-kb", "macae-contract-compliance-kb")
+            "6" = @("macae-content-gen-products-kb")
+            "7" = @(
+                "macae-retail-customer-kb", "macae-retail-orders-kb",
+                "macae-content-gen-products-kb",
+                "macae-contract-summary-kb", "macae-contract-risk-kb", "macae-contract-compliance-kb",
+                "macae-rfp-summary-kb", "macae-rfp-risk-kb", "macae-rfp-compliance-kb"
+            )
+        }
+
+        $selectedVectorStores = $vectorStoreMap[$useCaseSelection]
+        $selectedKbs          = $kbMap[$useCaseSelection]
+
+        # Vector stores — skip entirely if none for this use case
+        if ($selectedVectorStores.Count -gt 0) {
+            Write-Host ""
+            Write-Host "── Creating vector stores ──" -ForegroundColor Green
+            $vsFilter = ($selectedVectorStores -join ",")
+            $process = Start-Process -FilePath $pythonCmd -ArgumentList "infra/scripts/seed_vector_stores.py", "--only", $vsFilter -Wait -NoNewWindow -PassThru
+            if ($process.ExitCode -ne 0) {
+                Write-Host "  ERROR: Vector store creation failed. Run 'python infra/scripts/seed_vector_stores.py --only $vsFilter' manually." -ForegroundColor Red
+                $script:hasErrors = $true
+            } else {
+                Write-Host "  Vector stores created successfully."
+            }
+        }
+
+        # Knowledge bases + MCP connections
+        if ($selectedKbs.Count -gt 0) {
+            $kbFilter = ($selectedKbs -join ",")
+
+            Write-Host ""
+            Write-Host "── Seeding Foundry IQ Knowledge Bases ──" -ForegroundColor Green
+            $process = Start-Process -FilePath $pythonCmd -ArgumentList "infra/scripts/seed_knowledge_bases.py", "--only", $kbFilter -Wait -NoNewWindow -PassThru
+            if ($process.ExitCode -ne 0) {
+                Write-Host "  ERROR: Knowledge base seeding failed. Run 'python infra/scripts/seed_knowledge_bases.py --only $kbFilter' manually." -ForegroundColor Red
+                $script:hasErrors = $true
+            } else {
+                Write-Host "  Knowledge bases seeded successfully."
             }
 
-            query = "SELECT * FROM c WHERE c.data_type = 'team_config' AND c.name = @name"
-            params = [{"name": "@name", "value": json_data.get("name", "")}]
-            existing = [item async for item in container.query_items(query, parameters=params)]
-            if existing:
-                doc["id"] = existing[0]["id"]
-                doc["team_id"] = existing[0]["team_id"]
-                doc["session_id"] = existing[0]["session_id"]
-
-            try:
-                await container.upsert_item(body=doc)
-                verb = "Updated" if existing else "Created"
-                print(f"  {verb}: {json_data.get('name')} ({filepath.name})")
-                count += 1
-            except Exception as e:
-                print(f"  FAILED: {json_data.get('name')}: {str(e)[:120]}")
-
-    await cred.close()
-    await client.close()
-    print(f"  Done — {count} team(s) seeded.")
-
-asyncio.run(seed())
-"@
-
-$env:COSMOSDB_ENDPOINT = $cosmosEndpoint
-$env:COSMOSDB_DATABASE = $cosmosDatabase
-$env:COSMOSDB_CONTAINER = $cosmosContainer
-
-$seedTeamsScript | & $pythonCmd -
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  ERROR: Team config seeding had errors." -ForegroundColor Red
-    $script:hasErrors = $true
-}
-
-# ──────────────────────────────────────────────────────────────────────────────
-# 6. Deploy blob data and create search indexes
-# ──────────────────────────────────────────────────────────────────────────────
-
-# Map use cases to content packs that have data (blob/index operations)
-$dataPackMap = @{
-    "1" = @("content_packs/rfp_evaluation")
-    "2" = @("content_packs/retail_customer")
-    "3" = @()  # HR has no datasets
-    "4" = @()  # Marketing has no datasets
-    "5" = @("content_packs/contract_compliance")
-    "6" = @("content_packs/content_gen")
-    "7" = @(
-        "content_packs/rfp_evaluation",
-        "content_packs/retail_customer",
-        "content_packs/contract_compliance",
-        "content_packs/content_gen"
-    )
-}
-
-$selectedDataPacks = $dataPackMap[$useCaseSelection]
-
-if ($selectedDataPacks.Count -gt 0) {
-    Write-Host "`n── Step 2: Uploading blob data and creating search indexes ──" -ForegroundColor Green
-
-    $isSampleDataFailed = $false
-    foreach ($packPath in $selectedDataPacks) {
-        $result = Deploy-ContentPack -PackPath $packPath -StorageAccountName $storageAccount -AiSearchName $aiSearchName -PythonCmd $pythonCmd
-        if (-not $result) {
-            $isSampleDataFailed = $true
-            $script:hasErrors = $true
-            Write-Host "  Error in data deployment for $packPath" -ForegroundColor Red
+            Write-Host ""
+            Write-Host "── Creating KB MCP RemoteTool connections ──" -ForegroundColor Green
+            $process = Start-Process -FilePath $pythonCmd -ArgumentList "infra/scripts/seed_kb_connections.py", "--only", $kbFilter -Wait -NoNewWindow -PassThru
+            if ($process.ExitCode -ne 0) {
+                Write-Host "  ERROR: KB connection provisioning failed. Run 'python infra/scripts/seed_kb_connections.py --only $kbFilter' manually." -ForegroundColor Red
+                $script:hasErrors = $true
+            } else {
+                Write-Host "  KB MCP connections created successfully."
+            }
         }
     }
 
-    # ──────────────────────────────────────────────────────────────────────────
-    # 7. Create vector stores (Foundry file search)
-    # ──────────────────────────────────────────────────────────────────────────
-
-    Write-Host "`n── Step 3: Creating vector stores ──" -ForegroundColor Green
-
-    $env:AZURE_AI_PROJECT_ENDPOINT = $projectEndpoint
-    $process = Start-Process -FilePath $pythonCmd -ArgumentList "infra/scripts/seed_vector_stores.py" -Wait -NoNewWindow -PassThru
-    if ($process.ExitCode -ne 0) {
-        Write-Host "  ERROR: Vector store creation failed. Run 'python infra/scripts/seed_vector_stores.py' manually." -ForegroundColor Red
-        $script:hasErrors = $true
-    } else {
-        Write-Host "  Vector stores created successfully."
-    }
-
-    # ──────────────────────────────────────────────────────────────────────────
-    # 8. Create Foundry IQ Knowledge Bases
-    # ──────────────────────────────────────────────────────────────────────────
-
-    Write-Host "`n── Step 4: Seeding Foundry IQ Knowledge Bases ──" -ForegroundColor Green
-
-    $env:AZURE_AI_SEARCH_ENDPOINT = $searchEndpoint
-    $env:AZURE_OPENAI_ENDPOINT = $openaiEndpoint
-    $process = Start-Process -FilePath $pythonCmd -ArgumentList "infra/scripts/seed_knowledge_bases.py" -Wait -NoNewWindow -PassThru
-    if ($process.ExitCode -ne 0) {
-        Write-Host "  ERROR: Knowledge base seeding failed. Run 'python infra/scripts/seed_knowledge_bases.py' manually." -ForegroundColor Red
-        $script:hasErrors = $true
-    } else {
-        Write-Host "  Knowledge bases seeded successfully."
-    }
-
-    # ──────────────────────────────────────────────────────────────────────────
-    # 9. Create RemoteTool connections for KB MCP endpoints
-    # ──────────────────────────────────────────────────────────────────────────
-
-    Write-Host "`n── Step 5: Creating KB MCP RemoteTool connections ──" -ForegroundColor Green
-
-    $env:AZURE_AI_SEARCH_ENDPOINT = $searchEndpoint
-    $env:AZURE_AI_PROJECT_ENDPOINT = $projectEndpoint
-    $process = Start-Process -FilePath $pythonCmd -ArgumentList "infra/scripts/seed_kb_connections.py" -Wait -NoNewWindow -PassThru
-    if ($process.ExitCode -ne 0) {
-        Write-Host "  ERROR: KB connection provisioning failed. Run 'python infra/scripts/seed_kb_connections.py' manually." -ForegroundColor Red
-        $script:hasErrors = $true
-    } else {
-        Write-Host "  KB MCP connections created successfully."
-    }
-} else {
-    Write-Host "`n  Selected use case has no datasets to deploy — skipping blob/index/KB steps."
+} finally {
+    Write-Host ""
+    Restore-NetworkAccess
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -489,24 +815,20 @@ if ($selectedDataPacks.Count -gt 0) {
 # ──────────────────────────────────────────────────────────────────────────────
 
 if ($script:hasErrors) {
-    Write-Host "`n========================================" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Red
     Write-Host " Post-deployment seeding completed with ERRORS" -ForegroundColor Red
     Write-Host "========================================" -ForegroundColor Red
-    Write-Host "`nOne or more steps failed. Review the output above and re-run the failed steps manually." -ForegroundColor Yellow
     $frontendHost = $(azd env get-value webSiteDefaultHostname 2>$null)
-    if ($frontendHost) {
-        Write-Host "Frontend: https://$frontendHost"
-    }
+    if ($frontendHost) { Write-Host "Frontend: https://$frontendHost" }
     Write-Host ""
     exit 1
 } else {
-    Write-Host "`n========================================" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Green
     Write-Host " Post-deployment data seeding complete!" -ForegroundColor Green
     Write-Host "========================================" -ForegroundColor Green
-    Write-Host "`nThe application is ready to use."
     $frontendHost = $(azd env get-value webSiteDefaultHostname 2>$null)
-    if ($frontendHost) {
-        Write-Host "Frontend: https://$frontendHost"
-    }
+    if ($frontendHost) { Write-Host "Frontend: https://$frontendHost" }
     Write-Host ""
 }

--- a/infra/scripts/seed_kb_connections.py
+++ b/infra/scripts/seed_kb_connections.py
@@ -25,9 +25,9 @@ import httpx
 from azure.identity import DefaultAzureCredential
 from dotenv import load_dotenv
 
-# Load .env from src/backend/
+# Load .env from src/backend/ (override=False so env vars set by post_deploy.ps1 take precedence)
 _backend_env = Path(__file__).parent.parent / "src" / "backend" / ".env"
-load_dotenv(str(_backend_env), override=True)
+load_dotenv(str(_backend_env), override=False)
 
 SEARCH_ENDPOINT = os.environ.get("AZURE_AI_SEARCH_ENDPOINT", "").rstrip("/")
 PROJECT_ENDPOINT = os.environ.get("AZURE_AI_PROJECT_ENDPOINT", "").rstrip("/")
@@ -145,11 +145,24 @@ def _create_connection_via_arm(
         return False
 
 
+def _parse_only_filter() -> set[str] | None:
+    """Optional CLI filter: --only kb1,kb2  → only process those KB names."""
+    for i, arg in enumerate(sys.argv[1:], start=1):
+        if arg == "--only" and i + 1 < len(sys.argv):
+            return {n.strip() for n in sys.argv[i + 1].split(",") if n.strip()}
+        if arg.startswith("--only="):
+            return {n.strip() for n in arg.split("=", 1)[1].split(",") if n.strip()}
+    return None
+
+
 def main() -> None:
     """Provision RemoteTool connections for all knowledge bases."""
+    only_filter = _parse_only_filter()
+    selected_kbs = [k for k in KB_NAMES if only_filter is None or k in only_filter]
+
     print(f"Search endpoint: {SEARCH_ENDPOINT}")
     print(f"Project endpoint: {PROJECT_ENDPOINT}")
-    print(f"Knowledge bases: {len(KB_NAMES)}")
+    print(f"Knowledge bases: {len(selected_kbs)}{' (filtered)' if only_filter is not None else ''}")
     print()
 
     credential = DefaultAzureCredential()
@@ -181,7 +194,7 @@ def main() -> None:
     print()
 
     success_count = 0
-    for kb_name in KB_NAMES:
+    for kb_name in selected_kbs:
         connection_name = f"{kb_name}-mcp"
         target_url = f"{SEARCH_ENDPOINT}/knowledgebases/{kb_name}/mcp?api-version={KB_API_VERSION}"
 
@@ -195,8 +208,8 @@ def main() -> None:
         print()
 
     credential.close()
-    print(f"Done — {success_count}/{len(KB_NAMES)} connections provisioned.")
-    if success_count < len(KB_NAMES):
+    print(f"Done — {success_count}/{len(selected_kbs)} connections provisioned.")
+    if success_count < len(selected_kbs):
         sys.exit(1)
 
 

--- a/infra/scripts/seed_knowledge_bases.py
+++ b/infra/scripts/seed_knowledge_bases.py
@@ -337,15 +337,31 @@ def _create_knowledge_base(kb_name: str, kb_def: dict, headers: dict) -> None:
         print(f"    {resp.text[:200]}")
 
 
+def _parse_only_filter() -> set[str] | None:
+    """Optional CLI filter: --only kb1,kb2  → only process those KB names."""
+    for i, arg in enumerate(sys.argv[1:], start=1):
+        if arg == "--only" and i + 1 < len(sys.argv):
+            return {n.strip() for n in sys.argv[i + 1].split(",") if n.strip()}
+        if arg.startswith("--only="):
+            return {n.strip() for n in arg.split("=", 1)[1].split(",") if n.strip()}
+    return None
+
+
 def main() -> None:
     """Provision all knowledge bases."""
     print(f"Search endpoint: {SEARCH_ENDPOINT}")
     print(f"AI services endpoint: {AI_SERVICES_ENDPOINT or '(not set — KB will have no model)'}")
 
+    only_filter = _parse_only_filter()
+    if only_filter is not None:
+        print(f"Filter (--only): {sorted(only_filter)}")
+
     headers = _get_auth_headers()
     print()
 
     for kb_name, kb_def in KNOWLEDGE_BASES.items():
+        if only_filter is not None and kb_name not in only_filter:
+            continue
         print(f"── {kb_name} ──")
 
         # Step 1: Ensure semantic configs on each source index

--- a/infra/scripts/seed_vector_stores.py
+++ b/infra/scripts/seed_vector_stores.py
@@ -23,9 +23,9 @@ from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential
 from dotenv import load_dotenv
 
-# Load .env from src/backend/
+# Load .env from src/backend/ (override=False so env vars set by post_deploy.ps1 take precedence)
 _backend_env = Path(__file__).parent.parent / "src" / "backend" / ".env"
-load_dotenv(str(_backend_env), override=True)
+load_dotenv(str(_backend_env), override=False)
 
 PROJECT_ENDPOINT = os.environ.get("AZURE_AI_PROJECT_ENDPOINT")
 if not PROJECT_ENDPOINT:
@@ -136,9 +136,23 @@ def create_vector_store(oai, name: str, file_paths: list[Path]) -> str:
     return vs.id
 
 
+def _parse_only_filter() -> set[str] | None:
+    """Optional CLI filter: --only name1,name2  → only process those store names."""
+    for i, arg in enumerate(sys.argv[1:], start=1):
+        if arg == "--only" and i + 1 < len(sys.argv):
+            return {n.strip() for n in sys.argv[i + 1].split(",") if n.strip()}
+        if arg.startswith("--only="):
+            return {n.strip() for n in arg.split("=", 1)[1].split(",") if n.strip()}
+    return None
+
+
 def main():
     print(f"Project endpoint: {PROJECT_ENDPOINT}")
     print(f"Data directory: {DATA_DIR}")
+
+    only_filter = _parse_only_filter()
+    if only_filter is not None:
+        print(f"Filter (--only): {sorted(only_filter)}")
     print()
 
     credential = DefaultAzureCredential()
@@ -149,6 +163,8 @@ def main():
     oai = project.get_openai_client()
 
     for store_name, file_paths in VECTOR_STORES.items():
+        if only_filter is not None and store_name not in only_filter:
+            continue
         print(f"\n{'='*60}")
         print(f"Vector store: {store_name}")
         print(f"  Files: {[p.name for p in file_paths if p.is_file()]}")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces improvements to the infrastructure deployment scripts and templates, focusing on making deployments more flexible and maintainable. The main changes include refactoring the role assignment logic for the Search Service, and adding support for filtering which knowledge bases or vector stores to process via a new `--only` CLI option in the seeding scripts.

Key changes:

**Infrastructure deployment improvements:**

* Refactored the assignment of the "Cognitive Services OpenAI User" role to the Search Service's managed identity by moving the logic into a dedicated module (`modules/search-openai-role.bicep`). This allows deployments to work seamlessly across different resource groups and subscriptions, improving reusability and maintainability. (`infra/main.bicep`, `infra/modules/search-openai-role.bicep`) [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1970-R1978) [[2]](diffhunk://#diff-0265b4ce0b6b076b21bbe0120f760cd62975cbcfa0fe6c441cbe347d9d8cfee2R1-R24)

**Seeding script enhancements:**

* Added an optional `--only` CLI argument to the `seed_kb_connections.py`, `seed_knowledge_bases.py`, and `seed_vector_stores.py` scripts, enabling users to filter and process only specified knowledge bases or vector stores. This makes it easier to target specific resources during development or troubleshooting. (`infra/scripts/seed_kb_connections.py`, `infra/scripts/seed_knowledge_bases.py`, `infra/scripts/seed_vector_stores.py`) [[1]](diffhunk://#diff-7b8398c22a49d9b777ef00518f5f7dd03e4e2a4d20a092b780c4aa0751d7ec1dR148-R165) [[2]](diffhunk://#diff-7b8398c22a49d9b777ef00518f5f7dd03e4e2a4d20a092b780c4aa0751d7ec1dL184-R197) [[3]](diffhunk://#diff-7b8398c22a49d9b777ef00518f5f7dd03e4e2a4d20a092b780c4aa0751d7ec1dL198-R212) [[4]](diffhunk://#diff-84e336f21e04d8f7535c5e58c6e83f3310212e68941930bb18524abe0a0669f8R340-R364) [[5]](diffhunk://#diff-172bbdb736c6a07b79b366639b22ca1284271ed40f72cdcc9bffda9e1dba2ae4R139-R155) [[6]](diffhunk://#diff-172bbdb736c6a07b79b366639b22ca1284271ed40f72cdcc9bffda9e1dba2ae4R166-R167)

* Updated the `.env` loading behavior in the seeding scripts to avoid overriding environment variables set by deployment scripts, ensuring correct precedence and safer configuration management. (`infra/scripts/seed_kb_connections.py`, `infra/scripts/seed_vector_stores.py`) [[1]](diffhunk://#diff-7b8398c22a49d9b777ef00518f5f7dd03e4e2a4d20a092b780c4aa0751d7ec1dL28-R30) [[2]](diffhunk://#diff-172bbdb736c6a07b79b366639b22ca1284271ed40f72cdcc9bffda9e1dba2ae4L26-R28)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->