### PR TITLE
chore: Add Popup for timeout

### DIFF
--- a/src/frontend/src/components/common/SessionTimeoutDialog.tsx
+++ b/src/frontend/src/components/common/SessionTimeoutDialog.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogSurface,
+  DialogTitle,
+  DialogContent,
+  DialogBody,
+  DialogActions,
+  Button,
+} from '@fluentui/react-components';
+import { Clock20Regular } from '@fluentui/react-icons';
+import "../../styles/Panel.css";
+
+interface SessionTimeoutDialogProps {
+  isOpen: boolean;
+  onGoHome: () => void;
+}
+
+/**
+ * Non-dismissible dialog shown when the backend plan approval session times out.
+ * No close button, no outside click dismiss, no escape key dismiss.
+ */
+const SessionTimeoutDialog: React.FC<SessionTimeoutDialogProps> = ({
+  isOpen,
+  onGoHome,
+}) => {
+  return (
+    <Dialog
+      open={isOpen}
+      modalType="alert"
+      onOpenChange={() => {
+        // Prevent any dismiss action (escape key, outside click)
+      }}
+    >
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle
+            action={null}
+          >
+            <div className="plan-cancellation-dialog-title">
+              <Clock20Regular className="plan-cancellation-warning-icon" />
+              Session Timed Out
+            </div>
+          </DialogTitle>
+          <DialogContent>
+            Session timed out. Please go back to the home page.
+          </DialogContent>
+          <DialogActions>
+            <Button
+              appearance="primary"
+              onClick={onGoHome}
+            >
+              Go To Home
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+};
+
+export default SessionTimeoutDialog;

--- a/src/frontend/src/models/enums.tsx
+++ b/src/frontend/src/models/enums.tsx
@@ -253,6 +253,7 @@ export enum WebsocketMessageType {
     USER_CLARIFICATION_REQUEST = "user_clarification_request",
     USER_CLARIFICATION_RESPONSE = "user_clarification_response",
     FINAL_RESULT_MESSAGE = "final_result_message",
+    TIMEOUT_NOTIFICATION = "timeout_notification",
     ERROR_MESSAGE = 'error_message'
 }
 

--- a/src/frontend/src/pages/PlanPage.tsx
+++ b/src/frontend/src/pages/PlanPage.tsx
@@ -20,6 +20,7 @@ import { APIService } from "../api/apiService";
 import { StreamMessage, StreamingPlanUpdate } from "../models";
 import { usePlanCancellationAlert } from "../hooks/usePlanCancellationAlert";
 import PlanCancellationDialog from "../components/common/PlanCancellationDialog";
+import SessionTimeoutDialog from "../components/common/SessionTimeoutDialog";
 import "../styles/PlanPage.css"
 
 // Create API service instance
@@ -74,6 +75,9 @@ const PlanPage: React.FC = () => {
     const [showCancellationDialog, setShowCancellationDialog] = useState<boolean>(false);
     const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
     const [cancellingPlan, setCancellingPlan] = useState<boolean>(false);
+
+    // Session timeout dialog state
+    const [showSessionTimeoutDialog, setShowSessionTimeoutDialog] = useState<boolean>(false);
 
     const [loadingMessage, setLoadingMessage] = useState<string>(loadingMessages[0]);
 
@@ -442,6 +446,19 @@ const PlanPage: React.FC = () => {
 
         return () => unsubscribe();
     }, [scrollToBottom, showToast, formatErrorMessage]);
+
+    // WebsocketMessageType.TIMEOUT_NOTIFICATION
+    useEffect(() => {
+        const unsubscribe = webSocketService.on(WebsocketMessageType.TIMEOUT_NOTIFICATION, (timeoutMessage: any) => {
+            console.log('⏰ Timeout notification received:', timeoutMessage);
+            setShowSessionTimeoutDialog(true);
+            setShowProcessingPlanSpinner(false);
+            setShowBufferingText(false);
+            webSocketService.disconnect();
+        });
+
+        return () => unsubscribe();
+    }, []);
 
     //WebsocketMessageType.AGENT_MESSAGE
     useEffect(() => {
@@ -837,6 +854,15 @@ const PlanPage: React.FC = () => {
                 onConfirm={handleConfirmCancellation}
                 onCancel={handleCancelDialog}
                 loading={cancellingPlan}
+            />
+
+            {/* Session Timeout Dialog */}
+            <SessionTimeoutDialog
+                isOpen={showSessionTimeoutDialog}
+                onGoHome={() => {
+                    setShowSessionTimeoutDialog(false);
+                    navigate('/');
+                }}
             />
         </CoralShellColumn>
     );

--- a/src/frontend/src/services/WebSocketService.tsx
+++ b/src/frontend/src/services/WebSocketService.tsx
@@ -247,6 +247,11 @@ class WebSocketService {
             this.emit(WebsocketMessageType.ERROR_MESSAGE, message.data); // Emit the data
             break;
             }
+            case WebsocketMessageType.TIMEOUT_NOTIFICATION: {
+                console.log("Received TIMEOUT_NOTIFICATION:", message);
+                this.emit(WebsocketMessageType.TIMEOUT_NOTIFICATION, message);
+                break;
+            }
             case WebsocketMessageType.USER_CLARIFICATION_RESPONSE:
             case WebsocketMessageType.REPLAN_APPROVAL_REQUEST:
             case WebsocketMessageType.REPLAN_APPROVAL_RESPONSE:


### PR DESCRIPTION
## Purpose
This pull request adds robust handling for session timeouts in the frontend application. The main change is the introduction of a non-dismissible session timeout dialog that appears when the backend notifies the frontend of a session timeout via a new websocket message type. This ensures users receive clear feedback and are guided to return to the home page if their session expires.

**Session Timeout Handling:**

* Added a new non-dismissible `SessionTimeoutDialog` component to display a session timeout message and guide users back to the home page. (`src/frontend/src/components/common/SessionTimeoutDialog.tsx`)
* Integrated the `SessionTimeoutDialog` into `PlanPage`, including state management to show/hide the dialog and navigation logic to redirect users home when the dialog is acknowledged. (`src/frontend/src/pages/PlanPage.tsx`) [[1]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R23) [[2]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R79-R81) [[3]](diffhunk://#diff-512e49deca23bcd4952b6c2c14a8207f2345e755fa46b0ce925cbb8fde76de72R858-R866)

**Websocket Integration:**

* Added a new websocket message type, `TIMEOUT_NOTIFICATION`, to the `WebsocketMessageType` enum. (`src/frontend/src/models/enums.tsx`)
* Updated `WebSocketService` to handle the new `TIMEOUT_NOTIFICATION` message type and emit the appropriate event. (`src/frontend/src/services/WebSocketService.tsx`)
* Added a new effect in `PlanPage` to listen for the `TIMEOUT_NOTIFICATION` websocket event, display the session timeout dialog, and disconnect the websocket. (`src/frontend/src/pages/PlanPage.tsx`)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->