### PR TITLE
fix: remove unnecessary scrollToBottom call in usePlanWebSocket

### DIFF
--- a/src/App/src/hooks/usePlanWebSocket.tsx
+++ b/src/App/src/hooks/usePlanWebSocket.tsx
@@ -137,7 +137,6 @@ export function usePlanWebSocket({
                 const line = PlanDataService.simplifyHumanClarification(msg.data?.content || msg.content || '');
                 dispatch(setShowBufferingText(true));
                 dispatch(appendToStreamingBuffer(line));
-                //scrollToBottom();
             },
         );
         return unsub;

--- a/src/App/src/hooks/usePlanWebSocket.tsx
+++ b/src/App/src/hooks/usePlanWebSocket.tsx
@@ -137,11 +137,11 @@ export function usePlanWebSocket({
                 const line = PlanDataService.simplifyHumanClarification(msg.data?.content || msg.content || '');
                 dispatch(setShowBufferingText(true));
                 dispatch(appendToStreamingBuffer(line));
-                scrollToBottom();
+                //scrollToBottom();
             },
         );
         return unsub;
-    }, [dispatch, scrollToBottom]);
+    }, [dispatch]);
 
     // ── USER_CLARIFICATION_REQUEST ────────────────────────────────
     useEffect(() => {


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the `usePlanWebSocket` hook by removing the dependency on `scrollToBottom` in the effect that handles incoming WebSocket messages. This simplifies the effect's dependency array and removes an unnecessary function call.

- Removed the call to `scrollToBottom()` and its inclusion in the dependency array within the `usePlanWebSocket` hook in `usePlanWebSocket.tsx`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## What to Check
This pull request makes a minor update to the `usePlanWebSocket` hook by removing the dependency on `scrollToBottom` in the effect that handles streaming buffer updates. This simplifies the effect's dependency array and avoids unnecessary re-renders.

- Removed the call to `scrollToBottom()` and its inclusion in the dependencies array in the streaming buffer update effect in `usePlanWebSocket.tsx`

## Other Information


This pull request makes a minor adjustment to the `usePlanWebSocket` hook. The dependency on `scrollToBottom` has been removed from the effect, and the call to `scrollToBottom()` has been deleted from the message handler. This simplifies the effect and prevents unnecessary re-renders related to the `scrollToBottom` function.