### PR TITLE
fix: Code fix to handle replan request

### DIFF
--- a/src/backend/orchestration/orchestration_manager.py
+++ b/src/backend/orchestration/orchestration_manager.py
@@ -361,6 +361,7 @@ class OrchestrationManager:
             self.logger.info("Participant names: %s", participant_names)
 
             self.logger.info("Starting workflow execution...")
+            plan_already_approved = False
 
             # Initial run — stream events, collect any pending requests
             pending = await self._process_event_stream(
@@ -380,18 +381,30 @@ class OrchestrationManager:
 
                 # Handle plan reviews (present to user, wait for approval)
                 if plan_requests:
-                    self.logger.info(
-                        "Workflow paused with %d plan review request(s)",
-                        len(plan_requests),
-                    )
-                    plan_responses = await self._handle_plan_reviews(
-                        plan_requests,
-                        participant_names=participant_names,
-                        task_text=task_text,
-                        user_id=user_id,
-                    )
-                    if plan_responses is None:
-                        raise RuntimeError("Plan execution cancelled by user")
+                    if plan_already_approved:
+                        self.logger.info(
+                            "Auto-approving replanned workflow"
+                        )
+                        plan_responses = {
+                            request_id: plan_review.approve()
+                            for request_id, plan_review in plan_requests.items()
+                        }
+                    else:
+                        self.logger.info(
+                            "Workflow paused with %d plan review request(s)",
+                            len(plan_requests),
+                        )
+                        plan_responses = await self._handle_plan_reviews(
+                            plan_requests,
+                            participant_names=participant_names,
+                            task_text=task_text,
+                            user_id=user_id,
+                        )
+                        if plan_responses is None:
+                            raise RuntimeError("Plan execution cancelled by user")
+
+                        plan_already_approved = True
+
                     responses.update(plan_responses)
 
                 # Handle tool approval requests (clarification from user)


### PR DESCRIPTION
## Purpose
### Code fix to handle replan requests.

## Issue

When a user creates a task for the **Retail Success Team** for the first time, the Magentic orchestrator may not gather sufficient information to confidently complete the task. As a result, it triggers a **replanning event** during workflow execution.

The replanning event generates a new `MagenticPlanReviewRequest`, which was being handled the same way as the initial plan review. Consequently, `orchestration_manager.py` invoked `_handle_plan_reviews()` again, causing the workflow to pause and wait for user approval a second time.

This resulted in the user being redirected back to the **"Approve Plan"** screen, giving the impression that the workflow had failed, even though the orchestration was still active.

---

## Fix

Introduced a `plan_already_approved` flag to track whether the user has already approved the workflow plan.

```python
plan_already_approved = False
```

### Workflow

1. When the user approves the initial plan, the flag is set to `True`.
2. If a replanning event occurs after the initial approval, the workflow skips the `_handle_plan_reviews()` method, which would otherwise:
   - Send another `PLAN_APPROVAL_REQUEST` to the UI.
   - Pause the workflow.
   - Wait for user approval again.
3. Instead, replanned workflows are automatically approved by generating approval responses programmatically:

```python
plan_responses = {
    request_id: plan_review.approve()
    for request_id, plan_review in plan_requests.items()
}
```

### Benefits

- Prevents users from being sent back to the **Approve Plan** screen during internal replanning.
- Allows Magentic to continue executing replanned workflows without interruption.
- Preserves the framework's replanning capability while improving the user experience.
- Ensures that only the initial workflow plan requires explicit user approval.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->