### PR TITLE
fix: Consistent agent display names across UI 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,9 @@
 Test configuration for agent tests.
 """
 
+import sys
+from pathlib import Path
+
 import pytest
 
 # Add the agents path

--- a/src/backend/callbacks/response_handlers.py
+++ b/src/backend/callbacks/response_handlers.py
@@ -17,6 +17,44 @@ from orchestration.connection_config import connection_config
 logger = logging.getLogger(__name__)
 
 
+def format_agent_display_name(raw_name: str) -> str:
+    """Convert raw agent IDs (e.g. 'HRHelperAgent', 'hr_helper_agent') to
+    human-readable display names (e.g. 'HR Helper Agent').
+
+    Mirrors the frontend's getAgentDisplayName logic so names are consistent
+    across the AI Thinking buffer and agent message headers.
+    """
+    if not raw_name:
+        return "Assistant"
+
+    name = raw_name
+
+    # Replace underscores with spaces
+    name = name.replace("_", " ")
+
+    # Insert space before each uppercase letter preceded by a lowercase letter
+    # e.g. "HRHelperAgent" → "H R Helper Agent" (handled next)
+    name = re.sub(r'([a-z])([A-Z])', r'\1 \2', name)
+
+    # Insert space between consecutive uppercase and an uppercase+lowercase pair
+    # e.g. "HRHelper" → "HR Helper"
+    name = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1 \2', name)
+
+    # Collapse multiple spaces
+    name = re.sub(r'\s+', ' ', name).strip()
+
+    # Title-case each word
+    name = name.title()
+
+    # Fix common acronyms back to uppercase
+    for acronym in ['Hr', 'It', 'Ai', 'Api', 'Ui', 'Db', 'Kb']:
+        name = name.replace(acronym, acronym.upper())
+    # Fix double-uppercase replacements (e.g. "HRR" from "Hrr")
+    name = name.replace('HRR', 'HR R').replace('ITT', 'IT T')
+
+    return name
+
+
 def clean_citations(text: str) -> str:
     """Remove citation markers from agent responses while preserving formatting."""
     if not text:
@@ -66,6 +104,7 @@ def agent_response_callback(
     Final (non-streaming) agent response callback using agent_framework Message.
     """
     agent_name = getattr(message, "author_name", None) or agent_id or "Unknown Agent"
+    agent_name = format_agent_display_name(agent_name)
     role = getattr(message, "role", "assistant")
 
     # Message has a .text property that concatenates all TextContent items
@@ -107,6 +146,8 @@ async def streaming_agent_response_callback(
     if not user_id:
         return
 
+    display_name = format_agent_display_name(agent_id)
+
     try:
         chunk_text = getattr(update, "text", None)
         if not chunk_text:
@@ -123,7 +164,7 @@ async def streaming_agent_response_callback(
         contents = getattr(update, "contents", []) or []
         tool_calls = _extract_tool_calls_from_contents(contents)
         if tool_calls:
-            tool_message = AgentToolMessage(agent_name=agent_id)
+            tool_message = AgentToolMessage(agent_name=display_name)
             tool_message.tool_calls.extend(tool_calls)
             await connection_config.send_status_update_async(
                 tool_message,
@@ -134,7 +175,7 @@ async def streaming_agent_response_callback(
 
         if cleaned:
             streaming_payload = AgentMessageStreaming(
-                agent_name=agent_id,
+                agent_name=display_name,
                 content=cleaned,
                 is_final=is_final,
             )

--- a/src/backend/callbacks/response_handlers.py
+++ b/src/backend/callbacks/response_handlers.py
@@ -21,8 +21,9 @@ def format_agent_display_name(raw_name: str) -> str:
     """Convert raw agent IDs (e.g. 'HRHelperAgent', 'hr_helper_agent') to
     human-readable display names (e.g. 'HR Helper Agent').
 
-    Mirrors the frontend's getAgentDisplayName logic so names are consistent
-    across the AI Thinking buffer and agent message headers.
+    Applies similar splitting/casing logic as the frontend's
+    ``cleanTextToSpaces`` + ``getAgentDisplayName`` pipeline, but does NOT
+    strip the "Agent" suffix (the frontend handles that separately).
     """
     if not raw_name:
         return "Assistant"
@@ -33,7 +34,7 @@ def format_agent_display_name(raw_name: str) -> str:
     name = name.replace("_", " ")
 
     # Insert space before each uppercase letter preceded by a lowercase letter
-    # e.g. "HRHelperAgent" → "H R Helper Agent" (handled next)
+    # e.g. "HelperAgent" → "Helper Agent"
     name = re.sub(r'([a-z])([A-Z])', r'\1 \2', name)
 
     # Insert space between consecutive uppercase and an uppercase+lowercase pair
@@ -46,11 +47,11 @@ def format_agent_display_name(raw_name: str) -> str:
     # Title-case each word
     name = name.title()
 
-    # Fix common acronyms back to uppercase
-    for acronym in ['Hr', 'It', 'Ai', 'Api', 'Ui', 'Db', 'Kb']:
-        name = name.replace(acronym, acronym.upper())
-    # Fix double-uppercase replacements (e.g. "HRR" from "Hrr")
-    name = name.replace('HRR', 'HR R').replace('ITT', 'IT T')
+    # Fix common acronyms back to uppercase (word-boundary safe)
+    _ACRONYMS = {'Hr': 'HR', 'It': 'IT', 'Ai': 'AI', 'Api': 'API',
+                 'Ui': 'UI', 'Db': 'DB', 'Kb': 'KB'}
+    for title_form, upper_form in _ACRONYMS.items():
+        name = re.sub(rf'\b{title_form}\b', upper_form, name)
 
     return name
 

--- a/src/backend/orchestration/orchestration_manager.py
+++ b/src/backend/orchestration/orchestration_manager.py
@@ -16,6 +16,7 @@ from agent_framework_orchestrations import (MagenticBuilder,
                                             MagenticPlanReviewRequest)
 from agents.agent_factory import AgentFactory
 from callbacks.response_handlers import (agent_response_callback,
+                                         format_agent_display_name,
                                          streaming_agent_response_callback)
 from common.config.app_config import config
 from common.database.database_base import DatabaseBase
@@ -782,12 +783,12 @@ class OrchestrationManager:
                             and executor != current_streaming_agent_ref[0]
                         ):
                             current_streaming_agent_ref[0] = executor
-                            display_name = executor.replace("_", " ")
+                            display_name = format_agent_display_name(executor)
                             header_text = f"\n\n---\n### {display_name}\n\n"
                             try:
                                 await connection_config.send_status_update_async(
                                     AgentMessageStreaming(
-                                        agent_name=executor,
+                                        agent_name=display_name,
                                         content=header_text,
                                         is_final=False,
                                     ),

--- a/src/tests/backend/callbacks/test_response_handlers.py
+++ b/src/tests/backend/callbacks/test_response_handlers.py
@@ -134,6 +134,7 @@ sys.modules['models.messages'] = Mock(
 from backend.callbacks.response_handlers import (
     _extract_tool_calls_from_contents, _is_function_call_item,
     agent_response_callback, clean_citations,
+    format_agent_display_name,
     streaming_agent_response_callback)
 
 # Access mocked modules that we'll use in tests
@@ -216,7 +217,45 @@ class TestCleanCitations:
         assert clean_citations(text) == expected
 
 
-class TestIsFunctionCallItem:
+class TestFormatAgentDisplayName:
+    """Tests for the format_agent_display_name function."""
+
+    def test_empty_string_returns_assistant(self):
+        assert format_agent_display_name("") == "Assistant"
+
+    def test_none_returns_assistant(self):
+        assert format_agent_display_name(None) == "Assistant"
+
+    def test_pascal_case(self):
+        assert format_agent_display_name("ContentAgent") == "Content Agent"
+
+    def test_snake_case(self):
+        assert format_agent_display_name("content_agent") == "Content Agent"
+
+    def test_acronym_prefix(self):
+        assert format_agent_display_name("HRHelperAgent") == "HR Helper Agent"
+
+    def test_acronym_word_boundary_no_false_positive(self):
+        """Ensure 'It' inside 'Habit' is NOT replaced with 'IT'."""
+        assert format_agent_display_name("HabitAgent") == "Habit Agent"
+
+    def test_multiple_acronyms(self):
+        assert format_agent_display_name("AIApiAgent") == "AI API Agent"
+
+    def test_already_spaced(self):
+        assert format_agent_display_name("Content Agent") == "Content Agent"
+
+    def test_single_word(self):
+        assert format_agent_display_name("Triage") == "Triage"
+
+    def test_mixed_case_id(self):
+        assert format_agent_display_name("agent_123") == "Agent 123"
+
+    def test_consecutive_uppercase(self):
+        assert format_agent_display_name("DBAdmin") == "DB Admin"
+
+
+
     """Tests for the _is_function_call_item function."""
 
     def test_is_function_call_item_none(self):
@@ -415,7 +454,7 @@ class TestAgentResponseCallback:
 
             # Verify AgentMessage was created with cleaned text
             mock_agent_message.assert_called_once_with(
-                agent_name="TestAgent",
+                agent_name="Test Agent",
                 timestamp=1234567890.0,
                 content="Test message with citations "
             )
@@ -445,7 +484,7 @@ class TestAgentResponseCallback:
 
             # Verify AgentMessage was created with agent_id as agent_name
             mock_agent_message.assert_called_once_with(
-                agent_name="agent_123",
+                agent_name="Agent 123",
                 timestamp=1234567890.0,
                 content="Fallback message text"
             )
@@ -469,7 +508,7 @@ class TestAgentResponseCallback:
 
             # Verify AgentMessage was created with empty content
             mock_agent_message.assert_called_once_with(
-                agent_name="TestAgent",
+                agent_name="Test Agent",
                 timestamp=1234567890.0,
                 content=""
             )
@@ -515,7 +554,7 @@ class TestAgentResponseCallback:
             call_args = mock_logger.info.call_args[0]
             assert call_args[0] == "%s message (agent=%s): %s"
             assert call_args[1] == "Assistant"
-            assert call_args[2] == "TestAgent"
+            assert call_args[2] == "Test Agent"
             assert len(call_args[3]) == 193  # Message should be the actual length (not truncated in this case)
 
 
@@ -547,7 +586,7 @@ class TestStreamingAgentResponseCallback:
 
             # Verify AgentMessageStreaming was created with cleaned text
             mock_streaming.assert_called_once_with(
-                agent_name="agent_123",
+                agent_name="Agent 123",
                 content="Test streaming text ",
                 is_final=True
             )
@@ -587,7 +626,7 @@ class TestStreamingAgentResponseCallback:
 
             # Verify AgentMessageStreaming was created with concatenated content text
             mock_streaming.assert_called_once_with(
-                agent_name="agent_123",
+                agent_name="Agent 123",
                 content="Content from content attribute",
                 is_final=False
             )
@@ -640,7 +679,7 @@ class TestStreamingAgentResponseCallback:
                     await streaming_agent_response_callback("agent_123", mock_update, False, user_id="user_456")
 
                     # Verify tool message was created and sent
-                    mock_tool_message.assert_called_once_with(agent_name="agent_123")
+                    mock_tool_message.assert_called_once_with(agent_name="Agent 123")
                     # Verify tool_calls.extend was called with our mock tool call
                     assert mock_tool_call in mock_tool_msg.tool_calls or mock_tool_msg.tool_calls.extend.called  # type: ignore[union-attr]  # noqa: E1101  # pylint: disable=no-member
 
@@ -666,7 +705,7 @@ class TestStreamingAgentResponseCallback:
 
                 # Should still process the text
                 mock_streaming.assert_called_once_with(
-                    agent_name="agent_123",
+                    agent_name="Agent 123",
                     content="Test text",
                     is_final=True
                 )
@@ -733,7 +772,7 @@ class TestStreamingAgentResponseCallback:
                 await streaming_agent_response_callback("agent_123", mock_update, False, user_id="user_456")
 
                 # Verify tool message was created and tool calls were processed
-                mock_tool_message.assert_called_once_with(agent_name="agent_123")
+                mock_tool_message.assert_called_once_with(agent_name="Agent 123")
                 assert connection_config.send_status_update_async.called
 
     @pytest.mark.asyncio
@@ -751,7 +790,7 @@ class TestStreamingAgentResponseCallback:
 
             # Verify streaming message was created with correct parameters
             mock_streaming.assert_called_once_with(
-                agent_name="agent_123",
+                agent_name="Agent 123",
                 content="Test streaming text for processing",
                 is_final=True
             )


### PR DESCRIPTION
## Purpose
This pull request introduces a utility function to consistently format agent display names across the backend, ensuring that agent names are human-readable and match frontend conventions. The new formatting logic is applied throughout agent response handling and orchestration, replacing ad-hoc string manipulation with a centralized approach.

**Agent Display Name Formatting Improvements:**

* Added `format_agent_display_name` to `response_handlers.py`, converting raw agent IDs (like `HRHelperAgent` or `hr_helper_agent`) into human-readable names (like "HR Helper Agent"), mirroring frontend logic for consistency.
* Updated `agent_response_callback` and `streaming_agent_response_callback` to use `format_agent_display_name`, ensuring all agent names in responses and streaming updates are properly formatted. 

**Orchestration Consistency:**

* Modified `_process_event_stream` in `orchestration_manager.py` to use `format_agent_display_name` for agent headers and streaming messages, replacing previous underscore-to-space logic.

**Imports and Code Organization:**

* Added import of `format_agent_display_name` in `orchestration_manager.py` to support the new formatting logic.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## What to Check
This pull request introduces a utility function to standardize the formatting of agent display names across the backend, ensuring consistency with the frontend's naming conventions. The new function is integrated into several response handling and orchestration flows, so agent names are now presented in a more human-readable format throughout the application.

Key changes:

**Agent display name formatting:**

* Added a new `format_agent_display_name` function to `response_handlers.py` that converts raw agent identifiers (e.g., `HRHelperAgent`, `hr_helper_agent`) into human-readable display names (e.g., `HR Helper Agent`). This mirrors frontend logic for consistency.
* Updated `agent_response_callback` and `streaming_agent_response_callback` to use `format_agent_display_name` when setting agent names, ensuring all agent messages and tool calls display formatted names. 

**Orchestration integration:**

* Imported and used `format_agent_display_name` in `orchestration_manager.py` to format agent names in streaming event headers and message payloads, replacing previous ad-hoc formatting.

## Other Information

This pull request introduces a utility function to standardize the formatting of agent display names, ensuring consistency across backend and frontend components. The function is integrated into multiple places where agent names are shown to users, replacing previous ad-hoc formatting logic.

Key changes include:

**Agent Display Name Formatting:**

* Added a new `format_agent_display_name` function in `src/backend/callbacks/response_handlers.py` to convert raw agent IDs (e.g., `hr_helper_agent`, `HRHelperAgent`) into human-readable display names (e.g., "HR Helper Agent"), mirroring frontend logic for consistent naming.

**Integration of Formatting Utility:**

* Updated `agent_response_callback` and `streaming_agent_response_callback` in `src/backend/callbacks/response_handlers.py` to use `format_agent_display_name` when rendering agent names, ensuring all agent messages display standardized names. 

* Modified `_process_event_stream` in `src/backend/orchestration/orchestration_manager.py` to use `format_agent_display_name` for agent section headers and streaming messages, replacing previous underscore-based formatting.

* Updated imports in `src/backend/orchestration/orchestration_manager.py` to include the new formatting function.