### PR TITLE
fix: Enable session affinity to handle load accross multiple replicas

### DIFF
--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -1236,6 +1236,7 @@ module containerApp './modules/compute/container-app.bicep' = {
 module containerAppMcp './modules/compute/container-app.bicep' = {
   name: take('module.container-app-mcp.${solutionName}', 64)
   params: {
+    enableSessionAffinity : enableScalability? true: false
     name: 'ca-mcp-${solutionSuffix}'
     location: location
     tags: tags

--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -1236,7 +1236,7 @@ module containerApp './modules/compute/container-app.bicep' = {
 module containerAppMcp './modules/compute/container-app.bicep' = {
   name: take('module.container-app-mcp.${solutionName}', 64)
   params: {
-    enableSessionAffinity : enableScalability? true: false
+    stickySessionsAffinity : enableScalability? 'sticky': 'none'
     name: 'ca-mcp-${solutionSuffix}'
     location: location
     tags: tags

--- a/infra/avm/modules/compute/container-app.bicep
+++ b/infra/avm/modules/compute/container-app.bicep
@@ -62,6 +62,9 @@ param workloadProfileName string?
 @description('Enable Azure telemetry collection.')
 param enableTelemetry bool = true
 
+@description('Enable sticky session affinity.')
+param enableSessionAffinity bool = false
+
 // ============================================================================
 // Container App (AVM)
 // ============================================================================
@@ -74,6 +77,7 @@ module containerApp 'br/public:avm/res/app/container-app:0.22.1' = {
     enableTelemetry: enableTelemetry
     environmentResourceId: environmentResourceId
     containers: containers
+    stickySessionsAffinity: enableSessionAffinity? 'sticky': 'none'
     ingressExternal: disableIngress ? false : ingressExternal
     ingressTargetPort: ingressTargetPort
     ingressTransport: ingressTransport

--- a/infra/avm/modules/compute/container-app.bicep
+++ b/infra/avm/modules/compute/container-app.bicep
@@ -62,8 +62,12 @@ param workloadProfileName string?
 @description('Enable Azure telemetry collection.')
 param enableTelemetry bool = true
 
-@description('Enable sticky session affinity.')
-param enableSessionAffinity bool = false
+@allowed([
+  'none'
+  'sticky'
+])
+@description('Optional. Bool indicating if the Container App should enable session affinity.')
+param stickySessionsAffinity string = 'none'
 
 // ============================================================================
 // Container App (AVM)
@@ -77,7 +81,6 @@ module containerApp 'br/public:avm/res/app/container-app:0.22.1' = {
     enableTelemetry: enableTelemetry
     environmentResourceId: environmentResourceId
     containers: containers
-    stickySessionsAffinity: enableSessionAffinity? 'sticky': 'none'
     ingressExternal: disableIngress ? false : ingressExternal
     ingressTargetPort: ingressTargetPort
     ingressTransport: ingressTransport
@@ -90,6 +93,7 @@ module containerApp 'br/public:avm/res/app/container-app:0.22.1' = {
     activeRevisionsMode: activeRevisionsMode
     scaleSettings: scaleSettings
     workloadProfileName: workloadProfileName
+    stickySessionsAffinity: stickySessionsAffinity
   }
 }
 


### PR DESCRIPTION
## Purpose
Fix intermittent MCP session failures in WAF deployments by enabling sticky session affinity for the MCP Container App. This ensures requests belonging to the same MCP session are consistently routed to the same replica, preventing agent initialization failures during team switching in scaled deployments.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->