### PR TITLE
ci: pin third-party GitHub Actions to verified release SHAs

### DIFF
--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -24,17 +24,24 @@ jobs:
       - name: Get changed markdown files (PR only)
         id: changed-markdown-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            **/*.md
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- '*.md' | tr '\n' ' ' | sed 's/ *$//')
+          if [ -n "$changed_files" ]; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "all_changed_files=$changed_files" >> "$GITHUB_OUTPUT"
 
 
       # For PR: Check broken links only in changed files
       - name: Check Broken Links in Changed Markdown Files
         id: lychee-check-pr
         if: github.event_name == 'pull_request' && steps.changed-markdown-files.outputs.any_changed == 'true'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://
@@ -47,7 +54,7 @@ jobs:
       - name: Check Broken Links in All Markdown Files in Entire Repo (Manual Trigger)
         id: lychee-check-manual
         if: github.event_name == 'workflow_dispatch'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false &&
           env.skip_tests == 'false'
-        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        uses: MishaKav/pytest-coverage-comment@e48ae95fa406cefacc7fbdd79949122795569961 # v1.8.0
         with:
           pytest-xml-coverage-path: coverage.xml
           junitxml-path: pytest.xml


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Pin third-party GitHub Actions to specific release commit SHAs (instead of mutable version tags) for reproducible and immutable workflow runs.
* Replace the `tj-actions/changed-files` action in the broken-link checker with a built-in `git diff` step, which removes a third-party dependency from change detection.

Changes:
* `.github/workflows/broken-links-checker.yml` — replace `tj-actions/changed-files` with a built-in `git diff` step; pin `lycheeverse/lychee-action` to `8646ba3` (v2.8.0).
* `.github/workflows/pr-title-checker.yml` — pin `amannn/action-semantic-pull-request` to `48f2562` (v6.1.1).
* `.github/workflows/test.yml` — pin `MishaKav/pytest-coverage-comment` to `e48ae95` (v1.8.0).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout ci/pin-third-party-actions
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
# Open a PR that modifies a markdown file; the broken-links-checker workflow
# detects the changed .md files via git diff and runs lychee on them.
```

## What to Check
Verify that the following are valid
* The broken-links-checker workflow detects changed markdown files and runs lychee successfully.
* The pinned SHAs resolve to the indicated release tags.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
