### PR TITLE
fix: Updated the AvailabilityZone to -1 to resolve the quota issue

### DIFF
--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -692,7 +692,7 @@ module windowsVmDataCollectionRules './modules/monitoring/data-collection-rule.b
   }
 }
 
-var virtualMachineAvailabilityZone = 1
+var virtualMachineAvailabilityZone = -1
 module proximityPlacementGroup './modules/compute/proximity-placement-group.bicep' = if (enablePrivateNetworking) {
   name: take('module.proximity-placement-group.${solutionName}', 64)
   params: {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request makes a minor update to the `infra/avm/main.bicep` file, changing the default value of the `virtualMachineAvailabilityZone` variable from `1` to `-1`. This likely indicates a change in how availability zones are handled, possibly defaulting to "no specific zone" or "zone not set" instead of always assigning zone 1.

- Changed the default value of `virtualMachineAvailabilityZone` from `1` to `-1` in `infra/avm/main.bicep` to alter the default behavior for VM availability zone assignment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->