### PR TITLE
fix: resolve the destructive action bug

### DIFF
--- a/src/backend/orchestration/orchestration_manager.py
+++ b/src/backend/orchestration/orchestration_manager.py
@@ -603,31 +603,46 @@ class OrchestrationManager:
             examples_block = "\n".join(example_lines) or "- (none provided)"
 
             system_prompt = (
-                "You are a strict scope classifier for a specialized multi-agent "
-                "team. Decide whether a user's request falls within THIS team's "
-                "specialization.\n\n"
+                "You are a strict feasibility classifier for a specialized "
+                "multi-agent team. Decide whether a user's request can actually be "
+                "fulfilled by THIS team — considering BOTH (A) its specialization "
+                "and (B) what its agents are actually able to DO.\n\n"
                 "A team is defined ENTIRELY by its stated purpose, the specific "
                 "agents it has and what each does, the data/knowledge those agents "
                 "work with, and its representative example tasks.\n\n"
                 "Rules:\n"
                 "- IN SCOPE only if the request clearly matches this team's "
-                "specialization and could be fulfilled by these agents using their "
-                "data.\n"
-                "- OUT OF SCOPE if the request belongs to a DIFFERENT "
-                "specialization, even when superficially related or in a broadly "
-                "similar field (e.g. drafting a product press release is NOT the "
-                "same specialization as generating retail social-media content; HR "
-                "onboarding is NOT product marketing; contract/NDA compliance is "
+                "specialization AND the requested action is something these agents "
+                "can actually perform with their described capabilities and data.\n"
+                "- OUT OF SCOPE (kind=\"domain\") if the request belongs to a "
+                "DIFFERENT specialization, even when superficially related or in a "
+                "broadly similar field (e.g. drafting a product press release is NOT "
+                "the same specialization as generating retail social-media content; "
+                "HR onboarding is NOT product marketing; contract/NDA compliance is "
                 "NOT RFP evaluation).\n"
+                "- OUT OF SCOPE (kind=\"capability\") if the request asks the team to "
+                "perform an ACTION its agents cannot actually do. Agents generally "
+                "only retrieve, look up, analyze, summarize, or generate content "
+                "using their data. Unless an agent's description EXPLICITLY says it "
+                "can do so, the team CANNOT delete, erase, purge, remove, modify, "
+                "update, overwrite, or otherwise change stored data, and cannot "
+                "execute real-world side effects (place/cancel orders, send emails, "
+                "make payments, provision/deactivate accounts). Treat such requests "
+                "as OUT OF SCOPE — never let the team pretend it performed a "
+                "destructive or state-changing action it cannot actually perform.\n"
                 "- If the request is genuinely ambiguous or a reasonable subset of "
                 "the example tasks, treat it as IN SCOPE.\n\n"
                 "Respond with ONLY a compact JSON object and nothing else:\n"
-                '{"in_scope": true|false, "reason": "<one sentence>", '
+                '{"in_scope": true|false, "kind": "domain"|"capability"|"", '
+                '"reason": "<one sentence>", '
                 '"message": "<empty string if in scope; otherwise a short, polite '
-                "message telling the user this request is outside this team's scope "
-                "and that they should switch to the appropriate team and try again. "
-                "Do NOT name, recommend, or guess any specific team; do NOT list "
-                'what this team specializes in>"}'
+                "message. If kind=domain, say the request is outside this team's "
+                "scope and the user should switch to the appropriate team and try "
+                "again. If kind=capability, say this team cannot perform the "
+                "requested action (e.g. deleting or modifying stored data) and can "
+                "only help with the kinds of tasks its agents support; make clear "
+                "that NO data was changed. In both cases: do NOT name, recommend, or "
+                'guess any specific team; do NOT list what this team specializes in>"}'
             )
             user_prompt = (
                 f"TEAM NAME: {getattr(team_config, 'name', '')}\n"
@@ -653,16 +668,25 @@ class OrchestrationManager:
                 return None
 
             in_scope = bool(parsed.get("in_scope", True))
+            kind = str(parsed.get("kind", "") or "").strip().lower()
             message = str(parsed.get("message", "") or "").strip()
             if not in_scope and not message:
-                message = (
-                    "This request appears to be outside the scope of the selected "
-                    "team, so it cannot be handled reliably here. Please switch to "
-                    "the appropriate team and try again."
-                )
+                if kind == "capability":
+                    message = (
+                        "This team is not able to perform the requested action "
+                        "(such as deleting or modifying stored data). No data has "
+                        "been changed. It can only help with the kinds of tasks its "
+                        "agents support. Please try a supported request instead."
+                    )
+                else:
+                    message = (
+                        "This request appears to be outside the scope of the "
+                        "selected team, so it cannot be handled reliably here. "
+                        "Please switch to the appropriate team and try again."
+                    )
             self.logger.info(
-                "[SCOPE-GATE] in_scope=%s reason=%s",
-                in_scope, parsed.get("reason", ""),
+                "[SCOPE-GATE] in_scope=%s kind=%s reason=%s",
+                in_scope, kind, parsed.get("reason", ""),
             )
             return {"in_scope": in_scope, "message": message}
         except Exception as e:  # fail-open: never block a task on classifier error
@@ -749,8 +773,11 @@ class OrchestrationManager:
             MStep(
                 agent="MagenticManager",
                 action=(
-                    "Inform the user that this request is out of scope for the "
-                    "selected team and suggest a suitable team."
+                    "Inform the user that this request cannot be handled by the "
+                    "selected team — either because it falls outside the team's "
+                    "scope or because the team's agents cannot perform the "
+                    "requested action (such as deleting or modifying data) — and "
+                    "that no data was changed."
                 ),
             )
         ]

--- a/src/backend/orchestration/plan_review_helpers.py
+++ b/src/backend/orchestration/plan_review_helpers.py
@@ -100,20 +100,32 @@ CLARIFYING QUESTIONS POLICY (CRITICAL — ZERO QUESTIONS):
 
 TEAM SCOPE POLICY (CRITICAL — EVALUATE THIS FIRST, BEFORE ANY OTHER RULE):
 This team can ONLY handle requests that fall within the collective expertise of
-its listed agents. Each agent's description above tells you its domain and the
-data/knowledge it works on — that, and nothing else, defines the team's scope.
+its listed agents AND that ask for actions its agents can actually perform. Each
+agent's description above tells you its domain and the data/knowledge it works on —
+that, and nothing else, defines the team's scope and capabilities.
 
-Judge whether the user's request is covered by at least one listed agent's domain:
-- IN SCOPE: at least one agent's expertise/data is clearly relevant → plan normally.
-- OUT OF SCOPE: NO listed agent's domain covers the request (e.g. a contract /
-  compliance request given to a marketing or RFP team, or an HR / onboarding
-  request given to a product-marketing team). In this case you MUST NOT invoke any
-  domain agent. Output a plan with EXACTLY ONE step and nothing else:
-  [{{"agent": "MagenticManager", "action": "Inform the user that this request is out of scope for this team and that they should switch to the appropriate team and try again, without naming any specific team."}}]
+Judge whether the user's request is (a) covered by at least one listed agent's
+domain AND (b) an action the agents can actually perform:
+- IN SCOPE: at least one agent's expertise/data is relevant AND the requested
+  action is something the agents can do → plan normally.
+- OUT OF SCOPE — WRONG DOMAIN: NO listed agent's domain covers the request (e.g. a
+  contract / compliance request given to a marketing or RFP team, or an HR /
+  onboarding request given to a product-marketing team).
+- OUT OF SCOPE — UNSUPPORTED ACTION: the domain may match, but the request asks for
+  an action the agents CANNOT perform. Agents generally only retrieve, analyze,
+  summarize, or generate content from their data. Unless an agent's description
+  explicitly says otherwise, the team CANNOT delete, erase, remove, modify, update,
+  or overwrite stored data, nor execute real-world side effects (placing/cancelling
+  orders, sending emails, making payments). NEVER pretend such an action was done
+  (e.g. "Delete all data and order history for customer X").
+In EITHER out-of-scope case you MUST NOT invoke any domain agent. Output a plan with
+EXACTLY ONE step and nothing else:
+  [{{"agent": "MagenticManager", "action": "Inform the user that this request cannot be handled by this team — because it is outside the team's scope, or because the team cannot perform the requested action such as deleting or modifying data — and that no data was changed, without naming any specific team."}}]
 
 When out of scope, the mandatory-inclusion rule below does NOT apply — the lone
 MagenticManager step IS the complete, valid plan. Only take this path when the
-request is genuinely outside every agent's domain; when in doubt, plan normally.
+request is genuinely outside every agent's domain or asks for an action no agent can
+perform; when in doubt, plan normally.
 """
 
     plan_append = scope_policy + """
@@ -161,10 +173,13 @@ INVOCATION RULES:
 
 FINAL ANSWER RULES:
 - If the approved plan was a single out-of-scope MagenticManager step (no domain
-  agents ran), your final answer is a brief, polite message that states the
-  request is out of scope for this team and that the user should switch to the
-  appropriate team and try again. Do NOT name, recommend, or guess any specific
-  team, and do NOT attempt to answer the out-of-scope request itself.
+  agents ran), your final answer is a brief, polite message. If the request was
+  outside the team's domain, state that it is out of scope and that the user should
+  switch to the appropriate team and try again. If the request asked for an action
+  the team cannot perform (such as deleting or modifying stored data), state that
+  the team cannot perform that action and that NO data was changed. Do NOT name,
+  recommend, or guess any specific team, do NOT claim any action was performed, and
+  do NOT attempt to answer the out-of-scope request itself.
 - Compile ONLY from messages agents actually produced. Quote verbatim where appropriate.
 - Do NOT fabricate URLs, results, or content that no agent produced.
 - If a required agent step did not run, state it plainly — do not pretend it did.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request strengthens and clarifies how team scope and agent capabilities are evaluated and communicated throughout the orchestration system. The changes ensure that requests are only accepted if they both match a team's domain and can actually be fulfilled by its agents, and that users receive clear, accurate feedback when requests are out of scope—especially for actions the agents cannot perform (such as deleting or modifying data). Messaging and prompt templates have been updated across the codebase to reflect these stricter, more explicit policies.

**Scope and Capability Evaluation Policy Updates:**

* The system prompt in `_evaluate_team_scope` (`orchestration_manager.py`) now instructs the classifier to consider both the team's specialization and the actual capabilities of its agents, explicitly distinguishing between "domain" and "capability" out-of-scope cases. It also clarifies that destructive or state-changing actions are not allowed unless explicitly supported.
* The Magentic prompt template in `plan_review_helpers.py` was updated to require that requests must be both within an agent's domain and ask for actions the agents can actually perform, with explicit instructions for handling unsupported actions and clearer out-of-scope messaging.

**User Messaging and Logging Improvements:**

* When a request is out of scope, the returned message now differentiates between domain mismatches and unsupported actions, providing tailored explanations and ensuring users are told when no data was changed. Logging now also records the kind of out-of-scope reason.
* The out-of-scope handling step (`_handle_out_of_scope`) now informs users whether a request is out of scope due to domain or unsupported action, and always clarifies that no data was changed.
* The final answer rules in the Magentic prompt were updated to provide more specific, accurate, and polite user-facing messages for both domain and capability out-of-scope cases, and to reinforce that no unsupported actions are ever performed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->