### PR TITLE
refactor: update credential retrieval logic based on environment

### DIFF
--- a/src/mcp_server/services/image_service.py
+++ b/src/mcp_server/services/image_service.py
@@ -8,6 +8,7 @@ Foundry-hosted agents can embed in their markdown responses.
 
 import base64
 import logging
+import os
 import uuid
 
 
@@ -28,10 +29,11 @@ _IMAGE_API_VERSION = "2025-04-01-preview"
 
 
 def _get_credential():
-    """Return a credential, preferring user-assigned MI when a client id is set."""
-    if config.azure_client_id:
-        return ManagedIdentityCredential(client_id=config.azure_client_id)
-    return DefaultAzureCredential()
+    """Return a credential based on environment (dev vs deployed)."""
+    app_env = os.environ.get("APP_ENV", "prod").lower()
+    if app_env == "dev":
+        return DefaultAzureCredential(require_envvar=True)
+    return ManagedIdentityCredential(client_id=config.azure_client_id)
 
 
 def _ensure_container(blob_service: BlobServiceClient, container_name: str) -> None:


### PR DESCRIPTION
## Purpose
This pull request updates the logic for obtaining Azure credentials in the `image_service.py` service to better distinguish between development and production environments. The main change is to select the credential type based on the `APP_ENV` environment variable, improving local development experience and deployment flexibility.

Credential selection improvements:

* Updated the `_get_credential` function in `image_service.py` to use `DefaultAzureCredential` with `require_envvar=True` when `APP_ENV` is set to `dev`, and to use `ManagedIdentityCredential` with the configured client ID otherwise. This ensures that local development uses environment-based credentials, while production uses managed identity.
* Added an import for the `os` module to support reading environment variables.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Other Information

This pull request updates the logic for obtaining Azure credentials in the `image_service.py` to better support different environments (development vs. production). The main change is to select the appropriate credential type based on the `APP_ENV` environment variable.

**Credential selection improvements:**

* Modified the `_get_credential` function to check the `APP_ENV` environment variable and use `DefaultAzureCredential` in development environments and `ManagedIdentityCredential` in production, improving environment-specific authentication handling.
* Added `import os` to support reading environment variables for credential selection.