### PR TITLE
fix: Dev to main PR

### DIFF
--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -323,6 +323,8 @@ var supportedModels = [
 ]
 
 var containerAppName = 'ca-${solutionSuffix}'
+var backendUsesBootstrapImage = toLower(backendContainerRegistryHostname) == 'mcr.microsoft.com' && toLower(backendContainerImageName) == 'azuredocs/containerapps-helloworld'
+var mcpUsesBootstrapImage = toLower(MCPContainerRegistryHostname) == 'mcr.microsoft.com' && toLower(MCPContainerImageName) == 'azuredocs/containerapps-helloworld'
 
 var privateDnsZones = [
   'privatelink.cognitiveservices.azure.com'
@@ -1069,18 +1071,20 @@ module containerApp './modules/compute/container-app.bicep' = {
     tags: tags
     environmentResourceId: containerAppEnvironment.outputs.resourceId
     ingressExternal: true
-    ingressTargetPort: 8000
+    ingressTargetPort: backendUsesBootstrapImage ? 80 : 8000
     ingressAllowInsecure: false
     enableTelemetry: enableTelemetry
     managedIdentities: {
       userAssignedResourceIds: [managed_identity.outputs.resourceId]
     }
-    registries: [
-      {
-        server: acrLoginServer
-        identity: managed_identity.outputs.resourceId
-      }
-    ]
+    registries: backendUsesBootstrapImage
+      ? null
+      : [
+          {
+            server: acrLoginServer
+            identity: managed_identity.outputs.resourceId
+          }
+        ]
     corsPolicy: {
       allowedOrigins: [
         'https://app-${solutionSuffix}.azurewebsites.net'
@@ -1246,18 +1250,20 @@ module containerAppMcp './modules/compute/container-app.bicep' = {
     tags: tags
     environmentResourceId: containerAppEnvironment.outputs.resourceId
     ingressExternal: true
-    ingressTargetPort: 9000
+    ingressTargetPort: mcpUsesBootstrapImage ? 80 : 9000
     ingressAllowInsecure: false
     enableTelemetry: enableTelemetry
     managedIdentities: {
       userAssignedResourceIds: [managed_identity.outputs.resourceId]
     }
-    registries: [
-      {
-        server: acrLoginServer
-        identity: managed_identity.outputs.resourceId
-      }
-    ]
+    registries: mcpUsesBootstrapImage
+      ? null
+      : [
+          {
+            server: acrLoginServer
+            identity: managed_identity.outputs.resourceId
+          }
+        ]
     corsPolicy: {
       allowedOrigins: [
         'https://app-${solutionSuffix}.azurewebsites.net'

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "10080544909430391861"
+      "templateHash": "15518088603134439540"
     },
     "name": "Multi-Agent Custom Automation Engine - AVM",
     "description": "AVM orchestrator for the Multi-Agent Custom Automation Engine accelerator. Deploys the same logical resources and preserves the same outputs as infra\\main.bicep using local AVM wrapper modules."
@@ -467,6 +467,8 @@
       "[parameters('gptImageModelName')]"
     ],
     "containerAppName": "[format('ca-{0}', variables('solutionSuffix'))]",
+    "backendUsesBootstrapImage": "[and(equals(toLower(parameters('backendContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('backendContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
+    "mcpUsesBootstrapImage": "[and(equals(toLower(parameters('MCPContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('MCPContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
     "privateDnsZones": [
       "privatelink.cognitiveservices.azure.com",
       "privatelink.openai.azure.com",
@@ -687,7 +689,7 @@
     "aiSearchIndexNameForRFPSummary": "macae-rfp-summary-index",
     "aiSearchIndexNameForRFPRisk": "macae-rfp-risk-index",
     "aiSearchIndexNameForRFPCompliance": "macae-rfp-compliance-index",
-    "virtualMachineAvailabilityZone": 1,
+    "virtualMachineAvailabilityZone": -1,
     "aiFoundryOpenAIEndpoint": "[format('https://{0}.openai.azure.com/', variables('aiFoundryAiServicesResourceName'))]"
   },
   "resources": {
@@ -28583,7 +28585,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "10180502016624897684"
+              "templateHash": "13733831222630151234"
             }
           },
           "parameters": {
@@ -28609,7 +28611,7 @@
             "modelName": {
               "type": "string",
               "metadata": {
-                "description": "Required. Model name (e.g., gpt-4o, text-embedding-ada-002)."
+                "description": "Required. Model name (e.g., gpt-5.4-mini, text-embedding-ada-002)."
               }
             },
             "modelVersion": {
@@ -54859,9 +54861,7 @@
           "ingressExternal": {
             "value": true
           },
-          "ingressTargetPort": {
-            "value": 8000
-          },
+          "ingressTargetPort": "[if(variables('backendUsesBootstrapImage'), createObject('value', 80), createObject('value', 8000))]",
           "ingressAllowInsecure": {
             "value": false
           },
@@ -54875,14 +54875,7 @@
               ]
             }
           },
-          "registries": {
-            "value": [
-              {
-                "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value)]",
-                "identity": "[reference('managed_identity').outputs.resourceId.value]"
-              }
-            ]
-          },
+          "registries": "[if(variables('backendUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value), 'identity', reference('managed_identity').outputs.resourceId.value))))]",
           "corsPolicy": {
             "value": {
               "allowedOrigins": [
@@ -56862,9 +56855,7 @@
           "ingressExternal": {
             "value": true
           },
-          "ingressTargetPort": {
-            "value": 9000
-          },
+          "ingressTargetPort": "[if(variables('mcpUsesBootstrapImage'), createObject('value', 80), createObject('value', 9000))]",
           "ingressAllowInsecure": {
             "value": false
           },
@@ -56878,14 +56869,7 @@
               ]
             }
           },
-          "registries": {
-            "value": [
-              {
-                "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value)]",
-                "identity": "[reference('managed_identity').outputs.resourceId.value]"
-              }
-            ]
-          },
+          "registries": "[if(variables('mcpUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value), 'identity', reference('managed_identity').outputs.resourceId.value))))]",
           "corsPolicy": {
             "value": {
               "allowedOrigins": [
@@ -56967,8 +56951,16 @@
                     "value": "[parameters('gptImageModelName')]"
                   },
                   {
+                    "name": "AZURE_OPENAI_IMAGE_QUALITY",
+                    "value": "high"
+                  },
+                  {
                     "name": "AZURE_STORAGE_BLOB_URL",
                     "value": "[reference('storage_account').outputs.blobEndpoint.value]"
+                  },
+                  {
+                    "name": "AZURE_STORAGE_IMAGES_CONTAINER",
+                    "value": "generated-images"
                   },
                   {
                     "name": "BACKEND_URL",
@@ -59690,7 +59682,6 @@
             "value": {
               "SCM_DO_BUILD_DURING_DEPLOYMENT": "true",
               "DOCKER_REGISTRY_SERVER_URL": "[format('https://{0}', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value))]",
-              "WEBSITES_PORT": "3000",
               "WEBSITES_CONTAINER_START_TIME_LIMIT": "1800",
               "BACKEND_API_URL": "[format('https://{0}', reference('containerApp').outputs.fqdn.value)]",
               "AUTH_ENABLED": "false",
@@ -59698,6 +59689,12 @@
             }
           },
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
+          "vnetRouteAllEnabled": {
+            "value": "[parameters('enablePrivateNetworking')]"
+          },
+          "imagePullTraffic": {
+            "value": "[parameters('enablePrivateNetworking')]"
+          },
           "publicNetworkAccess": {
             "value": "Enabled"
           },
@@ -59712,7 +59709,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "9621160936099183182"
+              "templateHash": "9504607717010385151"
             }
           },
           "definitions": {
@@ -60250,6 +60247,40 @@
             }
           },
           "resources": {
+            "site": {
+              "existing": true,
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2025-03-01",
+              "name": "[parameters('name')]"
+            },
+            "logsConfig": {
+              "type": "Microsoft.Web/sites/config",
+              "apiVersion": "2025-03-01",
+              "name": "[format('{0}/{1}', parameters('name'), 'logs')]",
+              "properties": {
+                "applicationLogs": {
+                  "fileSystem": {
+                    "level": "Verbose"
+                  }
+                },
+                "detailedErrorMessages": {
+                  "enabled": true
+                },
+                "failedRequestsTracing": {
+                  "enabled": true
+                },
+                "httpLogs": {
+                  "fileSystem": {
+                    "enabled": true,
+                    "retentionInDays": 1,
+                    "retentionInMb": 35
+                  }
+                }
+              },
+              "dependsOn": [
+                "appService"
+              ]
+            },
             "appService": {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2025-04-01",
@@ -60293,6 +60324,7 @@
                       "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                       "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                       "appCommandLine": "[parameters('appCommandLine')]",
+                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
                       "acrUseManagedIdentityCreds": "[not(empty(parameters('acrUserManagedIdentityClientId')))]",
                       "acrUserManagedIdentityID": "[if(not(empty(parameters('acrUserManagedIdentityClientId'))), parameters('acrUserManagedIdentityClientId'), null())]"
                     }
@@ -60306,35 +60338,6 @@
                         "name": "appsettings",
                         "properties": "[parameters('appSettings')]",
                         "applicationInsightResourceId": "[if(not(empty(parameters('applicationInsightResourceId'))), parameters('applicationInsightResourceId'), null())]"
-                      },
-                      {
-                        "name": "logs",
-                        "properties": {
-                          "applicationLogs": {
-                            "fileSystem": {
-                              "level": "Verbose"
-                            }
-                          },
-                          "detailedErrorMessages": {
-                            "enabled": true
-                          },
-                          "failedRequestsTracing": {
-                            "enabled": true
-                          },
-                          "httpLogs": {
-                            "fileSystem": {
-                              "enabled": true,
-                              "retentionInDays": 1,
-                              "retentionInMb": 35
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "name": "web",
-                        "properties": {
-                          "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
-                        }
                       }
                     ]
                   },

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -243,6 +243,8 @@ var frontendAppUrl = 'https://${frontendAppName}.azurewebsites.net'
 var appServicePlanName = 'asp-${solutionSuffix}'
 var backendContainerAppName = 'ca-${solutionSuffix}'
 var mcpContainerAppName = 'ca-mcp-${solutionSuffix}'
+var backendUsesBootstrapImage = toLower(backendContainerRegistryHostname) == 'mcr.microsoft.com' && toLower(backendContainerImageName) == 'azuredocs/containerapps-helloworld'
+var mcpUsesBootstrapImage = toLower(MCPContainerRegistryHostname) == 'mcr.microsoft.com' && toLower(MCPContainerImageName) == 'azuredocs/containerapps-helloworld'
 var storageAccountName = take('st${toLower(replace(solutionSuffix, '-', ''))}', 24)
 var aiSearchServiceName = 'srch-${solutionSuffix}'
 
@@ -495,7 +497,7 @@ module backend_container_app './modules/compute/container-app.bicep' = {
     tags: isCustom ? union(allTags, { 'azd-service-name': 'backend' }) : allTags
     environmentResourceId: container_app_environment.outputs.resourceId
     ingressExternal: true
-    ingressTargetPort: 8000
+    ingressTargetPort: backendUsesBootstrapImage ? 80 : 8000
     managedIdentities: {
       userAssignedResourceIds: [userAssignedIdentity.outputs.resourceId]
     }
@@ -516,12 +518,14 @@ module backend_container_app './modules/compute/container-app.bicep' = {
       minReplicas: 1
       maxReplicas: 1
     }
-    registries: [
-      {
-        server: acrLoginServer
-        identity: userAssignedIdentity.outputs.resourceId
-      }
-    ]
+    registries: backendUsesBootstrapImage
+      ? null
+      : [
+          {
+            server: acrLoginServer
+            identity: userAssignedIdentity.outputs.resourceId
+          }
+        ]
     containers: [
       {
         name: 'backend'
@@ -669,7 +673,7 @@ module mcp_container_app './modules/compute/container-app.bicep' = {
     tags: isCustom ? union(allTags, { 'azd-service-name': 'mcp' }) : allTags
     environmentResourceId: container_app_environment.outputs.resourceId
     ingressExternal: true
-    ingressTargetPort: 9000
+    ingressTargetPort: mcpUsesBootstrapImage ? 80 : 9000
     managedIdentities: {
       userAssignedResourceIds: [userAssignedIdentity.outputs.resourceId]
     }
@@ -683,12 +687,14 @@ module mcp_container_app './modules/compute/container-app.bicep' = {
       minReplicas: 1
       maxReplicas: 1
     }
-    registries: [
-      {
-        server: acrLoginServer
-        identity: userAssignedIdentity.outputs.resourceId
-      }
-    ]
+    registries: mcpUsesBootstrapImage
+      ? null
+      : [
+          {
+            server: acrLoginServer
+            identity: userAssignedIdentity.outputs.resourceId
+          }
+        ]
     containers: [
       {
         name: 'mcp'

--- a/infra/bicep/main.json
+++ b/infra/bicep/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "11051305577029776274"
+      "templateHash": "12836920652912180859"
     },
     "name": "Multi-Agent Custom Automation Engine - Vanilla Bicep",
     "description": "Vanilla Bicep orchestrator for the Multi-Agent Custom Automation Engine accelerator. This deployment intentionally excludes WAF features such as private networking, scale-out, redundancy, bastion, and VM resources while keeping router-compatible outputs."
@@ -402,6 +402,8 @@
     "appServicePlanName": "[format('asp-{0}', variables('solutionSuffix'))]",
     "backendContainerAppName": "[format('ca-{0}', variables('solutionSuffix'))]",
     "mcpContainerAppName": "[format('ca-mcp-{0}', variables('solutionSuffix'))]",
+    "backendUsesBootstrapImage": "[and(equals(toLower(parameters('backendContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('backendContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
+    "mcpUsesBootstrapImage": "[and(equals(toLower(parameters('MCPContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('MCPContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
     "storageAccountName": "[take(format('st{0}', toLower(replace(variables('solutionSuffix'), '-', ''))), 24)]",
     "aiSearchServiceName": "[format('srch-{0}', variables('solutionSuffix'))]",
     "aiSearchIndexNameForContractSummary": "contract-summary-doc-index",
@@ -1217,7 +1219,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "10180502016624897684"
+              "templateHash": "13733831222630151234"
             }
           },
           "parameters": {
@@ -1243,7 +1245,7 @@
             "modelName": {
               "type": "string",
               "metadata": {
-                "description": "Required. Model name (e.g., gpt-4o, text-embedding-ada-002)."
+                "description": "Required. Model name (e.g., gpt-5.4-mini, text-embedding-ada-002)."
               }
             },
             "modelVersion": {
@@ -2691,9 +2693,7 @@
           "ingressExternal": {
             "value": true
           },
-          "ingressTargetPort": {
-            "value": 8000
-          },
+          "ingressTargetPort": "[if(variables('backendUsesBootstrapImage'), createObject('value', 80), createObject('value', 8000))]",
           "managedIdentities": {
             "value": {
               "userAssignedResourceIds": [
@@ -2722,14 +2722,7 @@
               "maxReplicas": 1
             }
           },
-          "registries": {
-            "value": [
-              {
-                "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value)]",
-                "identity": "[reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value]"
-              }
-            ]
-          },
+          "registries": "[if(variables('backendUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value), 'identity', reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value))))]",
           "containers": {
             "value": [
               {
@@ -3104,9 +3097,7 @@
           "ingressExternal": {
             "value": true
           },
-          "ingressTargetPort": {
-            "value": 9000
-          },
+          "ingressTargetPort": "[if(variables('mcpUsesBootstrapImage'), createObject('value', 80), createObject('value', 9000))]",
           "managedIdentities": {
             "value": {
               "userAssignedResourceIds": [
@@ -3128,14 +3119,7 @@
               "maxReplicas": 1
             }
           },
-          "registries": {
-            "value": [
-              {
-                "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value)]",
-                "identity": "[reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value]"
-              }
-            ]
-          },
+          "registries": "[if(variables('mcpUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value), 'identity', reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value))))]",
           "containers": {
             "value": [
               {
@@ -3203,8 +3187,16 @@
                     "value": "[parameters('gptImageModelName')]"
                   },
                   {
+                    "name": "AZURE_OPENAI_IMAGE_QUALITY",
+                    "value": "high"
+                  },
+                  {
                     "name": "AZURE_STORAGE_BLOB_URL",
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('module.storage-account.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.blobEndpoint.value]"
+                  },
+                  {
+                    "name": "AZURE_STORAGE_IMAGES_CONTAINER",
+                    "value": "[parameters('storageContainerNameGeneratedImages')]"
                   },
                   {
                     "name": "BACKEND_URL",
@@ -3619,7 +3611,6 @@
             "value": {
               "SCM_DO_BUILD_DURING_DEPLOYMENT": "true",
               "DOCKER_REGISTRY_SERVER_URL": "[format('https://{0}', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value))]",
-              "WEBSITES_PORT": "3000",
               "WEBSITES_CONTAINER_START_TIME_LIMIT": "1800",
               "BACKEND_API_URL": "[format('https://{0}', reference(resourceId('Microsoft.Resources/deployments', take(format('module.backend-container-app.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.fqdn.value)]",
               "AUTH_ENABLED": "false",

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "17775288733861273358"
+      "templateHash": "15739232766064275104"
     },
     "name": "Multi-Agent Custom Automation Engine - Deployment Router",
     "description": "Deployment router for the Multi-Agent Custom Automation Engine accelerator. Routes to either the AVM or vanilla Bicep orchestrator and preserves a unified deployment contract."
@@ -561,7 +561,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "6216243501205527784"
+              "templateHash": "6625237371109264103"
             },
             "name": "Multi-Agent Custom Automation Engine - AVM",
             "description": "AVM orchestrator for the Multi-Agent Custom Automation Engine accelerator. Deploys the same logical resources and preserves the same outputs as infra\\main.bicep using local AVM wrapper modules."
@@ -957,7 +957,7 @@
             "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
             "allTags": "[union(createObject('azd-env-name', parameters('solutionName')), parameters('tags'))]",
             "existingTags": "[coalesce(resourceGroup().tags, createObject())]",
-            "resourceTags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'MACAE', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'SolutionSuffix', variables('solutionSuffix')))]",
+            "resourceTags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'MACAE', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'SolutionSuffix', variables('solutionSuffix'), 'SecurityControl', 'Ignore'))]",
             "useExistingLogAnalytics": "[not(empty(parameters('existingLogAnalyticsWorkspaceId')))]",
             "existingLawSubscription": "[if(variables('useExistingLogAnalytics'), split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], '')]",
             "existingLawResourceGroup": "[if(variables('useExistingLogAnalytics'), split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4], '')]",
@@ -1022,6 +1022,8 @@
               "[parameters('gptImageModelName')]"
             ],
             "containerAppName": "[format('ca-{0}', variables('solutionSuffix'))]",
+            "backendUsesBootstrapImage": "[and(equals(toLower(parameters('backendContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('backendContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
+            "mcpUsesBootstrapImage": "[and(equals(toLower(parameters('MCPContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('MCPContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
             "privateDnsZones": [
               "privatelink.cognitiveservices.azure.com",
               "privatelink.openai.azure.com",
@@ -55414,9 +55416,7 @@
                   "ingressExternal": {
                     "value": true
                   },
-                  "ingressTargetPort": {
-                    "value": 8000
-                  },
+                  "ingressTargetPort": "[if(variables('backendUsesBootstrapImage'), createObject('value', 80), createObject('value', 8000))]",
                   "ingressAllowInsecure": {
                     "value": false
                   },
@@ -55430,14 +55430,7 @@
                       ]
                     }
                   },
-                  "registries": {
-                    "value": [
-                      {
-                        "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value)]",
-                        "identity": "[reference('managed_identity').outputs.resourceId.value]"
-                      }
-                    ]
-                  },
+                  "registries": "[if(variables('backendUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value), 'identity', reference('managed_identity').outputs.resourceId.value))))]",
                   "corsPolicy": {
                     "value": {
                       "allowedOrigins": [
@@ -57417,9 +57410,7 @@
                   "ingressExternal": {
                     "value": true
                   },
-                  "ingressTargetPort": {
-                    "value": 9000
-                  },
+                  "ingressTargetPort": "[if(variables('mcpUsesBootstrapImage'), createObject('value', 80), createObject('value', 9000))]",
                   "ingressAllowInsecure": {
                     "value": false
                   },
@@ -57433,14 +57424,7 @@
                       ]
                     }
                   },
-                  "registries": {
-                    "value": [
-                      {
-                        "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value)]",
-                        "identity": "[reference('managed_identity').outputs.resourceId.value]"
-                      }
-                    ]
-                  },
+                  "registries": "[if(variables('mcpUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference('container_registry').outputs.loginServer.value), 'identity', reference('managed_identity').outputs.resourceId.value))))]",
                   "corsPolicy": {
                     "value": {
                       "allowedOrigins": [
@@ -76904,7 +76888,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "1904819476144963209"
+              "templateHash": "12836920652912180859"
             },
             "name": "Multi-Agent Custom Automation Engine - Vanilla Bicep",
             "description": "Vanilla Bicep orchestrator for the Multi-Agent Custom Automation Engine accelerator. This deployment intentionally excludes WAF features such as private networking, scale-out, redundancy, bastion, and VM resources while keeping router-compatible outputs."
@@ -77301,6 +77285,8 @@
             "appServicePlanName": "[format('asp-{0}', variables('solutionSuffix'))]",
             "backendContainerAppName": "[format('ca-{0}', variables('solutionSuffix'))]",
             "mcpContainerAppName": "[format('ca-mcp-{0}', variables('solutionSuffix'))]",
+            "backendUsesBootstrapImage": "[and(equals(toLower(parameters('backendContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('backendContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
+            "mcpUsesBootstrapImage": "[and(equals(toLower(parameters('MCPContainerRegistryHostname')), 'mcr.microsoft.com'), equals(toLower(parameters('MCPContainerImageName')), 'azuredocs/containerapps-helloworld'))]",
             "storageAccountName": "[take(format('st{0}', toLower(replace(variables('solutionSuffix'), '-', ''))), 24)]",
             "aiSearchServiceName": "[format('srch-{0}', variables('solutionSuffix'))]",
             "aiSearchIndexNameForContractSummary": "contract-summary-doc-index",
@@ -79590,9 +79576,7 @@
                   "ingressExternal": {
                     "value": true
                   },
-                  "ingressTargetPort": {
-                    "value": 8000
-                  },
+                  "ingressTargetPort": "[if(variables('backendUsesBootstrapImage'), createObject('value', 80), createObject('value', 8000))]",
                   "managedIdentities": {
                     "value": {
                       "userAssignedResourceIds": [
@@ -79621,14 +79605,7 @@
                       "maxReplicas": 1
                     }
                   },
-                  "registries": {
-                    "value": [
-                      {
-                        "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value)]",
-                        "identity": "[reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value]"
-                      }
-                    ]
-                  },
+                  "registries": "[if(variables('backendUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value), 'identity', reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value))))]",
                   "containers": {
                     "value": [
                       {
@@ -80003,9 +79980,7 @@
                   "ingressExternal": {
                     "value": true
                   },
-                  "ingressTargetPort": {
-                    "value": 9000
-                  },
+                  "ingressTargetPort": "[if(variables('mcpUsesBootstrapImage'), createObject('value', 80), createObject('value', 9000))]",
                   "managedIdentities": {
                     "value": {
                       "userAssignedResourceIds": [
@@ -80027,14 +80002,7 @@
                       "maxReplicas": 1
                     }
                   },
-                  "registries": {
-                    "value": [
-                      {
-                        "server": "[if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value)]",
-                        "identity": "[reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value]"
-                      }
-                    ]
-                  },
+                  "registries": "[if(variables('mcpUsesBootstrapImage'), createObject('value', null()), createObject('value', createArray(createObject('server', if(variables('useExistingContainerRegistry'), format('{0}.azurecr.io', variables('existingContainerRegistryName')), reference(resourceId('Microsoft.Resources/deployments', take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.loginServer.value), 'identity', reference(resourceId('Microsoft.Resources/deployments', take(format('module.user-assigned-identity.{0}', variables('solutionSuffix')), 64)), '2025-04-01').outputs.resourceId.value))))]",
                   "containers": {
                     "value": [
                       {

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "15739232766064275104"
+      "templateHash": "13731968440732364764"
     },
     "name": "Multi-Agent Custom Automation Engine - Deployment Router",
     "description": "Deployment router for the Multi-Agent Custom Automation Engine accelerator. Routes to either the AVM or vanilla Bicep orchestrator and preserves a unified deployment contract."
@@ -561,7 +561,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "6625237371109264103"
+              "templateHash": "15518088603134439540"
             },
             "name": "Multi-Agent Custom Automation Engine - AVM",
             "description": "AVM orchestrator for the Multi-Agent Custom Automation Engine accelerator. Deploys the same logical resources and preserves the same outputs as infra\\main.bicep using local AVM wrapper modules."
@@ -957,7 +957,7 @@
             "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
             "allTags": "[union(createObject('azd-env-name', parameters('solutionName')), parameters('tags'))]",
             "existingTags": "[coalesce(resourceGroup().tags, createObject())]",
-            "resourceTags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'MACAE', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'SolutionSuffix', variables('solutionSuffix'), 'SecurityControl', 'Ignore'))]",
+            "resourceTags": "[union(variables('existingTags'), variables('allTags'), createObject('TemplateName', 'MACAE', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'SolutionSuffix', variables('solutionSuffix')))]",
             "useExistingLogAnalytics": "[not(empty(parameters('existingLogAnalyticsWorkspaceId')))]",
             "existingLawSubscription": "[if(variables('useExistingLogAnalytics'), split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], '')]",
             "existingLawResourceGroup": "[if(variables('useExistingLogAnalytics'), split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4], '')]",

--- a/infra/scripts/post-provision/Build-And-Push-Images.ps1
+++ b/infra/scripts/post-provision/Build-And-Push-Images.ps1
@@ -87,6 +87,54 @@ function Get-EnvOrAzd {
     return $Default
 }
 
+function Update-ContainerAppImageAndPort {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$ResourceGroup,
+        [Parameter(Mandatory)][string]$ContainerName,
+        [Parameter(Mandatory)][string]$Image,
+        [Parameter(Mandatory)][int]$TargetPort,
+        [Parameter(Mandatory)][string]$RegistryServer
+    )
+
+    $configPath = Join-Path ([System.IO.Path]::GetTempPath()) "$Name-$([guid]::NewGuid().ToString('N')).json"
+    try {
+        $appJson = & az containerapp show --name $Name --resource-group $ResourceGroup --output json
+        if ($LASTEXITCODE -ne 0 -or -not $appJson) {
+            throw "Failed to read Container App '$Name'."
+        }
+        $app = ($appJson -join [Environment]::NewLine) | ConvertFrom-Json
+
+        $container = $app.properties.template.containers | Where-Object { $_.name -eq $ContainerName } | Select-Object -First 1
+        if (-not $container) {
+            throw "Container '$ContainerName' was not found in Container App '$Name'."
+        }
+
+        $identityResourceId = $app.identity.userAssignedIdentities.PSObject.Properties.Name | Select-Object -First 1
+        if (-not $identityResourceId) {
+            throw "Container App '$Name' does not have a user-assigned identity for ACR image pulls."
+        }
+
+        $container.image = $Image
+        $app.properties.configuration.ingress.targetPort = $TargetPort
+        $app.properties.configuration.registries = @(
+            @{
+                server = $RegistryServer
+                identity = $identityResourceId
+            }
+        )
+        $app | ConvertTo-Json -Depth 100 | Set-Content -Path $configPath -Encoding utf8
+
+        & az containerapp update --name $Name --resource-group $ResourceGroup --yaml $configPath --output none
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to update Container App '$Name' to image '$Image' on port $TargetPort."
+        }
+    }
+    finally {
+        Remove-Item -Path $configPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 # --- Skip switch handling ---------------------------------------------------
 if ($Skip -or ([Environment]::GetEnvironmentVariable('AZURE_ENV_SKIP_IMAGE_BUILD') -eq 'true')) {
     Write-Host 'AZURE_ENV_SKIP_IMAGE_BUILD=true or -Skip specified. Skipping container image build & push.' -ForegroundColor Yellow
@@ -219,12 +267,22 @@ $mcpRef      = "$acrEndpoint/$mcpImage`:$ImageTag"
 $frontendRef = "$acrEndpoint/$frontendImage`:$ImageTag"
 
 Write-Host "Updating backend Container App -> $backendRef"
-& az containerapp update --name $backendCa --resource-group $resourceGroup --image $backendRef --output none
-if ($LASTEXITCODE -ne 0) { throw "Failed to update backend Container App '$backendCa'." }
+Update-ContainerAppImageAndPort `
+    -Name $backendCa `
+    -ResourceGroup $resourceGroup `
+    -ContainerName 'backend' `
+    -Image $backendRef `
+    -TargetPort 8000 `
+    -RegistryServer $acrEndpoint
 
 Write-Host "Updating MCP Container App -> $mcpRef"
-& az containerapp update --name $mcpCa --resource-group $resourceGroup --image $mcpRef --output none
-if ($LASTEXITCODE -ne 0) { throw "Failed to update MCP Container App '$mcpCa'." }
+Update-ContainerAppImageAndPort `
+    -Name $mcpCa `
+    -ResourceGroup $resourceGroup `
+    -ContainerName 'mcp' `
+    -Image $mcpRef `
+    -TargetPort 9000 `
+    -RegistryServer $acrEndpoint
 
 Write-Host "Updating Frontend Web App -> $frontendRef"
 & az webapp config container set `

--- a/infra/scripts/post-provision/build_and_push_images.sh
+++ b/infra/scripts/post-provision/build_and_push_images.sh
@@ -32,9 +32,58 @@ require() {
     fi
 }
 
+update_container_app_image_and_port() {
+    local app_name="$1"
+    local container_name="$2"
+    local image="$3"
+    local target_port="$4"
+    local registry_server="$5"
+    local config_file
+
+    config_file="$(mktemp)"
+
+    if ! az containerapp show \
+        --name "${app_name}" \
+        --resource-group "${RESOURCE_GROUP}" \
+        --output json |
+        jq \
+            --arg container_name "${container_name}" \
+            --arg image "${image}" \
+            --arg registry_server "${registry_server}" \
+            --argjson target_port "${target_port}" \
+            '(.identity.userAssignedIdentities | keys[0]) as $identity_resource_id
+             | if $identity_resource_id == null then error("Container App does not have a user-assigned identity for ACR image pulls") else . end
+             | (.properties.template.containers[] | select(.name == $container_name).image) = $image
+             | .properties.configuration.ingress.targetPort = $target_port
+             | .properties.configuration.registries = [{
+                 server: $registry_server,
+                 identity: $identity_resource_id
+               }]' \
+            > "${config_file}"; then
+        rm -f "${config_file}"
+        return 1
+    fi
+
+    if ! az containerapp update \
+        --name "${app_name}" \
+        --resource-group "${RESOURCE_GROUP}" \
+        --yaml "${config_file}" \
+        --output none; then
+        rm -f "${config_file}"
+        return 1
+    fi
+
+    rm -f "${config_file}"
+}
+
 if [ "${AZURE_ENV_SKIP_IMAGE_BUILD:-}" = "true" ]; then
     echo "AZURE_ENV_SKIP_IMAGE_BUILD=true. Skipping container image build & push."
     exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: 'jq' is required to update Container App images and ingress ports." >&2
+    exit 1
 fi
 
 section "Reading azd environment values"
@@ -156,18 +205,10 @@ MCP_REF="${ACR_ENDPOINT}/${MCP_IMAGE}:${IMAGE_TAG}"
 FRONTEND_REF="${ACR_ENDPOINT}/${FRONTEND_IMAGE}:${IMAGE_TAG}"
 
 echo "Updating backend Container App -> ${BACKEND_REF}"
-az containerapp update \
-    --name "${BACKEND_CA}" \
-    --resource-group "${RESOURCE_GROUP}" \
-    --image "${BACKEND_REF}" \
-    --output none
+update_container_app_image_and_port "${BACKEND_CA}" "backend" "${BACKEND_REF}" 8000 "${ACR_ENDPOINT}"
 
 echo "Updating MCP Container App -> ${MCP_REF}"
-az containerapp update \
-    --name "${MCP_CA}" \
-    --resource-group "${RESOURCE_GROUP}" \
-    --image "${MCP_REF}" \
-    --output none
+update_container_app_image_and_port "${MCP_CA}" "mcp" "${MCP_REF}" 9000 "${ACR_ENDPOINT}"
 
 echo "Updating Frontend Web App -> ${FRONTEND_REF}"
 az webapp config container set \

--- a/infra/scripts/post-provision/build_and_push_images.sh
+++ b/infra/scripts/post-provision/build_and_push_images.sh
@@ -47,11 +47,17 @@ update_container_app_image_and_port() {
         --resource-group "${RESOURCE_GROUP}" \
         --output json |
         jq \
+            --arg app_name "${app_name}" \
             --arg container_name "${container_name}" \
             --arg image "${image}" \
             --arg registry_server "${registry_server}" \
             --argjson target_port "${target_port}" \
-            '(.identity.userAssignedIdentities | keys[0]) as $identity_resource_id
+            'if any(.properties.template.containers[]?; .name == $container_name) then
+                 .
+             else
+                 error("Container \($container_name) was not found in Container App \($app_name)")
+             end
+             | (.identity.userAssignedIdentities | keys[0]) as $identity_resource_id
              | if $identity_resource_id == null then error("Container App does not have a user-assigned identity for ACR image pulls") else . end
              | (.properties.template.containers[] | select(.name == $container_name).image) = $image
              | .properties.configuration.ingress.targetPort = $target_port


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces logic to better handle deployments using the default Microsoft Container Registry (MCR) "bootstrap" images for backend and MCP container apps. The main improvements include automatically adjusting the ingress port and omitting registry configuration when the bootstrap image is detected, as well as several infrastructure enhancements and minor fixes.

**Container App Deployment Logic:**
- **Bootstrap Image Detection:** Added logic to detect if the backend or MCP container image is the default MCR bootstrap image (`azuredocs/containerapps-helloworld`). This detection is exposed via new variables (`backendUsesBootstrapImage`, `mcpUsesBootstrapImage`). [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR326-R327) [[2]](diffhunk://#diff-6d5bbaf49aff20fcd5df30e6b6780f53182fdf8f71e8c25950e24d94d50e2612R246-R247) [[3]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fR470-R471) [[4]](diffhunk://#diff-a9c0ff862c2ddf7d893af29e946199ace2a134f3d51fa3071e6e35a7b0b6c0b2R405-R406)
- **Dynamic Ingress Port:** The container app ingress port is now set to `80` if using the bootstrap image, otherwise it defaults to the previous values (`8000` for backend, `9000` for MCP). [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL1072-R1082) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL1249-R1261) [[3]](diffhunk://#diff-6d5bbaf49aff20fcd5df30e6b6780f53182fdf8f71e8c25950e24d94d50e2612L498-R500) [[4]](diffhunk://#diff-6d5bbaf49aff20fcd5df30e6b6780f53182fdf8f71e8c25950e24d94d50e2612L672-R676) [[5]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL54862-R54864) [[6]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL56865-R56858)
- **Registry Configuration:** If using the bootstrap image, container registry credentials are omitted (`registries` set to `null`). Otherwise, the registry configuration remains as before. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL1072-R1082) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL1249-R1261) [[3]](diffhunk://#diff-6d5bbaf49aff20fcd5df30e6b6780f53182fdf8f71e8c25950e24d94d50e2612L519-R523) [[4]](diffhunk://#diff-6d5bbaf49aff20fcd5df30e6b6780f53182fdf8f71e8c25950e24d94d50e2612L686-R692) [[5]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL54878-R54878) [[6]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL56881-R56872)

**Infrastructure and Configuration Enhancements:**
- **App Service Logging:** Introduced a new `logsConfig` resource for App Service with verbose logging, error messages, and HTTP logs enabled. This replaces the previous inline `logs` configuration. [[1]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fR60250-R60283) [[2]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL60309-L60337)
- **Networking Parameters:** Added `vnetRouteAllEnabled` and `imagePullTraffic` parameters to support private networking scenarios. [[1]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL59693-R59697) [[2]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fR60327)
- **Environment Variables:** Added new environment variables for image quality and storage container in the backend.

**Other Minor Updates:**
- Updated template hashes and metadata for Bicep-generated JSON files. [[1]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL9-R9) [[2]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL28586-R28588) [[3]](diffhunk://#diff-ac703cdc1a63d20f6804d2a91efeb5c8754cd680722682d53ada361533db450fL59715-R59712) [[4]](diffhunk://#diff-a9c0ff862c2ddf7d893af29e946199ace2a134f3d51fa3071e6e35a7b0b6c0b2L8-R8) [[5]](diffhunk://#diff-a9c0ff862c2ddf7d893af29e946199ace2a134f3d51fa3071e6e35a7b0b6c0b2L1220-R1222)
- Changed the default `virtualMachineAvailabilityZone` value from `1` to `-1`.
- Updated the model name example in parameter metadata.

These changes improve deployment flexibility, especially for quick starts and demos using the default bootstrap image, and enhance logging and networking capabilities for production scenarios.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->