### PR TITLE
fix: updated the team upload functionality while rerunning the post deployment script to fix duplicate team issue

### DIFF
--- a/infra/scripts/post-provision/upload_team_config.py
+++ b/infra/scripts/post-provision/upload_team_config.py
@@ -115,22 +115,6 @@ uploaded_count = 0
 for filename, team_id in candidate_files:
     file_path = os.path.join(directory_path, filename)
     print(f"Uploading file:  {filename}")
-    team_exists = check_team_exists(backend_url, team_id, user_principal_id)
-    if team_exists:
-        # Delete existing team to allow re-upload with updated config
-        print(f"Team (ID: {team_id}) already exists. Deleting to re-upload with latest config...")
-        delete_endpoint = backend_url.rstrip('/') + f'/api/v4/team_configs/{team_id}'
-        headers = {
-            'x-ms-client-principal-id': user_principal_id
-        }
-        try:
-            delete_response = request_with_retry("DELETE", delete_endpoint, headers=headers)
-            if delete_response.status_code == 200:
-                print(f"Successfully deleted existing team (ID: {team_id}).")
-            else:
-                print(f"Warning: Could not delete existing team (ID: {team_id}). Status: {delete_response.status_code}. Will attempt upload anyway.")
-        except Exception as e:
-            print(f"Warning: Exception deleting team (ID: {team_id}): {str(e)}. Will attempt upload anyway.")
 
     try:
         with open(file_path, 'rb') as file_data:

--- a/src/backend/api/router.py
+++ b/src/backend/api/router.py
@@ -1008,7 +1008,7 @@ async def upload_team_config(
                     {
                         "status": "failed",
                         "user_id": user_id,
-                        "filename": file.filename,
+                        "file_name": file.filename,
                         "reason": rai_error,
                     },
                 )
@@ -1016,7 +1016,7 @@ async def upload_team_config(
 
         track_event_if_configured(
             "Config_RAI_Validation_Passed",
-            {"status": "passed", "user_id": user_id, "filename": file.filename},
+            {"status": "passed", "user_id": user_id, "file_name": file.filename},
         )
         team_service = TeamService(memory_store)
 
@@ -1034,7 +1034,7 @@ async def upload_team_config(
                 {
                     "status": "failed",
                     "user_id": user_id,
-                    "filename": file.filename,
+                    "file_name": file.filename,
                     "missing_models": missing_models,
                 },
             )
@@ -1042,7 +1042,7 @@ async def upload_team_config(
 
         track_event_if_configured(
             "Config_Model_Validation_Passed",
-            {"status": "passed", "user_id": user_id, "filename": file.filename},
+            {"status": "passed", "user_id": user_id, "file_name": file.filename},
         )
 
         # Validate search indexes
@@ -1061,7 +1061,7 @@ async def upload_team_config(
                 {
                     "status": "failed",
                     "user_id": user_id,
-                    "filename": file.filename,
+                    "file_name": file.filename,
                     "search_errors": search_errors,
                 },
             )
@@ -1070,7 +1070,7 @@ async def upload_team_config(
         logger.info(f"Search validation passed for user: {user_id}")
         track_event_if_configured(
             "Config_Search_Validation_Passed",
-            {"status": "passed", "user_id": user_id, "filename": file.filename},
+            {"status": "passed", "user_id": user_id, "file_name": file.filename},
         )
 
         # Validate and parse the team configuration

--- a/src/backend/services/team_service.py
+++ b/src/backend/services/team_service.py
@@ -164,6 +164,11 @@ class TeamService:
         """
         Save team configuration to the database.
 
+        Idempotent by team_id: if a team with the same team_id already exists
+        (including shared default teams), reuse its document id and partition
+        key (session_id) and upsert; otherwise create a new document. This
+        prevents duplicate rows accumulating on re-runs of the seed script.
+
         Args:
             team_config: TeamConfiguration object to save
 
@@ -171,12 +176,25 @@ class TeamService:
             The unique ID of the saved configuration
         """
         try:
-            # Use the specific add_team method from cosmos memory context
-            await self.memory_context.add_team(team_config)
-
-            self.logger.info(
-                "Successfully saved team configuration with ID: %s", team_config.id
-            )
+            existing = await self.memory_context.get_team(team_config.team_id)
+            if existing is not None:
+                # Preserve immutable identity fields; partition key (session_id)
+                # cannot change on an upsert.
+                team_config.id = existing.id
+                team_config.session_id = existing.session_id
+                team_config.created = existing.created
+                team_config.created_by = existing.created_by
+                await self.memory_context.update_team(team_config)
+                self.logger.info(
+                    "Successfully updated team configuration with ID: %s",
+                    team_config.id,
+                )
+            else:
+                await self.memory_context.add_team(team_config)
+                self.logger.info(
+                    "Successfully saved team configuration with ID: %s",
+                    team_config.id,
+                )
             return team_config.id
 
         except Exception as e:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request makes improvements to the team configuration upload and storage process, focusing on making uploads idempotent, cleaning up the upload logic, and standardizing API field names. The main changes are grouped below:

**Idempotent team configuration storage:**

* The `save_team_configuration` method in `team_service.py` now ensures that saving a team config is idempotent by team ID. If a team with the same ID already exists, it updates the existing record instead of creating a duplicate, preserving immutable fields like the document ID and partition key. This prevents duplicate teams when re-running the seed script.

**Upload logic simplification:**

* The logic in `upload_team_config.py` for deleting and re-uploading existing teams was removed, as the backend now handles idempotency. This simplifies the upload process and reduces unnecessary delete operations.

**API field name standardization:**

* In `router.py`, all API responses and event tracking related to team config uploads now use the field name `file_name` instead of `filename`, ensuring consistency across the API. [[1]](diffhunk://#diff-a13f23ec10b6a3adabe05c1e2d1af3494c103536aa0858749c949058e3cbf28eL1011-R1019) [[2]](diffhunk://#diff-a13f23ec10b6a3adabe05c1e2d1af3494c103536aa0858749c949058e3cbf28eL1037-R1045) [[3]](diffhunk://#diff-a13f23ec10b6a3adabe05c1e2d1af3494c103536aa0858749c949058e3cbf28eL1064-R1064) [[4]](diffhunk://#diff-a13f23ec10b6a3adabe05c1e2d1af3494c103536aa0858749c949058e3cbf28eL1073-R1073)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->