### PR TITLE
fix: Dev Container venv path to avoid Docker bind-mount OSError

### DIFF
--- a/infra/scripts/post-provision/post_deploy.sh
+++ b/infra/scripts/post-provision/post_deploy.sh
@@ -16,7 +16,12 @@ resource_group=""
 user_principal_id=""
 ai_foundry_resource_id=""
 python_cmd=""
-venv_path="$SCRIPT_DIR/scriptenv"
+# Dev container bind-mounts cause OSError on large packages; use $HOME Path instead.
+if [ -n "${REMOTE_CONTAINERS:-}" ] || [ -n "${CODESPACES:-}" ] || [ -f "/run/.containerenv" ] || grep -qF "microsoft.com/devcontainers" /etc/os-release 2>/dev/null; then
+  venv_path="$HOME/.macae-post-provision-env"
+else
+  venv_path="$SCRIPT_DIR/scriptenv"
+fi
 
 st_is_public_access_disabled=false
 srch_is_public_access_disabled=false


### PR DESCRIPTION
## Purpose
This pull request updates the `post_deploy.sh` script to improve compatibility with development container environments. The main change is to adjust the location of the Python virtual environment to avoid issues with bind-mounted directories in containers.

Environment compatibility improvement:

* The script now checks if it is running in a development container (such as VS Code Dev Containers, GitHub Codespaces, or similar) and sets the `venv_path` to a directory in the user's home (`$HOME/.macae-post-provision-env`) instead of the script directory. This avoids `OSError` issues that can occur with bind-mounted directories when installing large Python packages.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->